### PR TITLE
Install EXIT handler for gracefully termination

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,8 @@ on:
   push:
     branches: [ main ]
     paths-ignore: [ '.github/**' ]
+  pull_request:
+    branches: [ main ]
 
 env:
   DEBS_PATH: ${{ inputs.DEBS_PATH || vars.DEBS_PATH || '~/debs' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,6 @@ jobs:
               err=1
             fi
           done
-          exit $err
 
   ci:
     runs-on: ubuntu-latest

--- a/src/scripts/generic.sh
+++ b/src/scripts/generic.sh
@@ -8,6 +8,8 @@ SRC_PATH="$(realpath "$DIR_THIS/..")"
 # shellcheck source=src/env.sh
 source "$SRC_PATH/env.sh"
 
+ici_setup
+
 ici_start_fold "Variables"
 cat <<EOF
 ROS_DISTRO=$ROS_DISTRO
@@ -28,3 +30,5 @@ ici_end_fold
 
 # shellcheck source=main.sh
 source "$1"
+
+ici_teardown

--- a/src/util.sh
+++ b/src/util.sh
@@ -19,12 +19,14 @@ _CLEANUP=""
 __ici_log_fd=1
 __ici_err_fd=2
 __ici_top_level=0
+__ici_setup_called=false
 
 function ici_setup {
     trap 'ici_trap_exit' EXIT # install exit handler
     exec {__ici_log_fd}>&1
     exec {__ici_err_fd}>&2
     __ici_top_level=$BASH_SUBSHELL
+    __ici_setup_called=true
 }
 
 function ici_redirect {
@@ -213,11 +215,10 @@ function ici_timed {
 function ici_teardown {
     # don't run teardown code within subshells, but only at top level
     if [  "$BASH_SUBSHELL" -le "$__ici_top_level" ]; then
-        local exit_code=$1
-        local called_from_signal_handler; called_from_signal_handler=${2:-false}
+        local exit_code=${1:-0}
 
         # Reset signal handler since the shell is about to exit.
-        [ "$called_from_signal_handler" == true ] && trap - EXIT
+        [ "$__ici_setup_called" == true ] && trap - EXIT
 
         local cleanup=()
         # shellcheck disable=SC2016
@@ -236,11 +237,11 @@ function ici_teardown {
             else
               ici_end_fold "$ICI_FOLD_NAME"
             fi
-        else
+        elif [ "$exit_code" -ne "0" ]; then
             gha_error "Failure with exit code: $exit_code"
         fi
 
-        if [ "$called_from_signal_handler" = true ]; then
+        if [ "$__ici_setup_called" = true ]; then
             # These will fail if ici_setup was not called
             exec {__ici_log_fd}>&-
             exec {__ici_err_fd}>&-
@@ -254,7 +255,7 @@ function ici_trap_exit {
     ici_warn "terminated unexpectedly with exit code '$exit_code'"
     TRACE=true ici_backtrace "$@"
     exit_code=143
-    ici_teardown "$exit_code" true
+    ici_teardown "$exit_code"
     exit "$exit_code"
 }
 

--- a/sub.sh
+++ b/sub.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+HOOK="for i in 1 2 3; do echo -n '.' ; sleep 1 ; done"
+ici_hook HOOK

--- a/test.sh
+++ b/test.sh
@@ -5,9 +5,7 @@ REPO_PATH=/tmp/repo
 SRC_PATH="$PWD/src"
 
 source "$SRC_PATH/env.sh"
+
 ici_setup
-
-HOOK="for i in 1 2 3; do echo -n '.' ; sleep 1 ; done"
-ici_hook HOOK
-
+. sub.sh
 ici_teardown

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# shellcheck disable=SC2034,1091
+DEBS_PATH=/tmp/debs
+REPO_PATH=/tmp/repo
+SRC_PATH="$PWD/src"
+
+source "$SRC_PATH/env.sh"
+ici_setup
+
+HOOK="for i in 1 2 3; do echo -n '.' ; sleep 1 ; done"
+ici_hook HOOK
+
+ici_teardown


### PR DESCRIPTION
To leave a comment with which package a job was failing, we should react to EXIT signals. 
According to this [discussion](https://github.com/orgs/community/discussions/26311#discussioncomment-3251359), github sends appropriate signals. However, we need to forward those signals from our .js script to the shell script.

Relevant docs:
- [Basic Hello World example](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action)
- [.js / .ts action template repositories](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#template-repositories-for-creating-javascript-actions)
- [debugging workflow](https://github.com/ringerc/github-actions-signal-handling-demo) using `run` steps
- https://nodejs.org/api/child_process.html#synchronous-process-creation