### PR TITLE
import package set from ros-o-builder

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -29,11 +29,11 @@ repositories:
     version: master
   apriltag:
     type: git
-    url: https://github.com/AprilRobotics/apriltag
+    url: https://github.com/AprilRobotics/apriltag.git
     version: master
   apriltag_ros:
     type: git
-    url: https://github.com/AprilRobotics/apriltag_ros
+    url: https://github.com/AprilRobotics/apriltag_ros.git
     version: master
   audio_common:
     type: git
@@ -53,7 +53,7 @@ repositories:
     version: master
   bond_core:
     type: git
-    url: https://github.com/ros-o/bond_core
+    url: https://github.com/ros-o/bond_core.git
     version: obese-devel
   boost_sml:
     type: git
@@ -61,7 +61,7 @@ repositories:
     version: obese-devel
   catkin:
     type: git
-    url: https://github.com/ubi-agni/catkin
+    url: https://github.com/ubi-agni/catkin.git
     version: noetic-devel
   class_loader:
     type: git
@@ -93,7 +93,7 @@ repositories:
     version: kinetic-devel
   control_toolbox:
     type: git
-    url: https://github.com/ros-o/control_toolbox
+    url: https://github.com/ros-o/control_toolbox.git
     version: obese-devel
   convex_decomposition:
     type: git
@@ -129,7 +129,7 @@ repositories:
     version: eigenpy-ros-release-release-noetic-eigenpy-2.9.2-1
   eml:
     type: git
-    url: https://github.com/ros-o/eml
+    url: https://github.com/ros-o/eml.git
     version: main
   ethercat_grant:
     type: git
@@ -145,7 +145,7 @@ repositories:
     version: melodic-devel
   fake_joint:
     type: git
-    url: https://github.com/ros-o/fake_joint
+    url: https://github.com/ros-o/fake_joint.git
     version: obese-devel
   fcl:
     type: git
@@ -197,15 +197,15 @@ repositories:
     version: main
   geometric_shapes:
     type: git
-    url: https://github.com/ros-planning/geometric_shapes
+    url: https://github.com/ros-planning/geometric_shapes.git
     version: noetic-devel
   geometry:
     type: git
-    url: https://github.com/ros-o/geometry
+    url: https://github.com/ros-o/geometry.git
     version: obese-devel
   geometry2:
     type: git
-    url: https://github.com/ros-o/geometry2
+    url: https://github.com/ros-o/geometry2.git
     version: obese-devel
   geometry_tutorials:
     type: git
@@ -233,7 +233,7 @@ repositories:
     version: master
   image_common:
     type: git
-    url: https://github.com/ros-perception/image_common
+    url: https://github.com/ros-perception/image_common.git
     version: noetic-devel
   image_pipeline:
     type: git
@@ -245,7 +245,7 @@ repositories:
     version: noetic-devel
   interactive_markers:
     type: git
-    url: https://github.com/ros-o/interactive_markers
+    url: https://github.com/ros-o/interactive_markers.git
     version: obese-devel
   ivcon:
     type: git
@@ -253,7 +253,7 @@ repositories:
     version: melodic-devel
   joint_state_publisher:
     type: git
-    url: https://github.com/ros/joint_state_publisher
+    url: https://github.com/ros/joint_state_publisher.git
     version: noetic-devel
   joystick_drivers:
     type: git
@@ -261,7 +261,7 @@ repositories:
     version: obese-devel
   kdl_parser:
     type: git
-    url: https://github.com/ros-o/kdl_parser
+    url: https://github.com/ros-o/kdl_parser.git
     version: obese-devel
   laser_assembler:
     type: git
@@ -273,7 +273,7 @@ repositories:
     version: noetic-devel
   laser_geometry:
     type: git
-    url: https://github.com/ros-o/laser_geometry
+    url: https://github.com/ros-o/laser_geometry.git
     version: obese-devel
   laser_pipeline:
     type: git
@@ -289,7 +289,7 @@ repositories:
     version: master
   media_export:
     type: git
-    url: https://github.com/ros/media_export
+    url: https://github.com/ros/media_export.git
     version: kinetic-devel
   message_generation:
     type: git
@@ -313,23 +313,23 @@ repositories:
     version: master
   moveit_msgs:
     type: git
-    url: https://github.com/ros-planning/moveit_msgs
+    url: https://github.com/ros-planning/moveit_msgs.git
     version: master
   moveit_resources:
     type: git
-    url: https://github.com/ros-planning/moveit_resources
+    url: https://github.com/ros-planning/moveit_resources.git
     version: master
   moveit_task_constructor:
     type: git
-    url: https://github.com/ubi-agni/moveit_task_constructor
+    url: https://github.com/ubi-agni/moveit_task_constructor.git
     version: master
   moveit_tutorials:
     type: git
-    url: https://github.com/ros-planning/moveit_tutorials
+    url: https://github.com/ros-planning/moveit_tutorials.git
     version: master
   moveit_visual_tools:
     type: git
-    url: https://github.com/rhaschke/moveit_visual_tools
+    url: https://github.com/rhaschke/moveit_visual_tools.git
     version: noetic-devel
   navigation_msgs:
     type: git
@@ -365,11 +365,11 @@ repositories:
     version: noetic-devel
   pcl_msgs:
     type: git
-    url: https://github.com/ros-perception/pcl_msgs
+    url: https://github.com/ros-perception/pcl_msgs.git
     version: noetic-devel
   perception_pcl:
     type: git
-    url: https://github.com/ros-o/perception_pcl
+    url: https://github.com/ros-o/perception_pcl.git
     version: obese-devel
   plotjuggler:
     type: git
@@ -377,11 +377,11 @@ repositories:
     version: main
   plotjuggler_msgs:
     type: git
-    url: https://github.com/facontidavide/plotjuggler_msgs
+    url: https://github.com/facontidavide/plotjuggler_msgs.git
     version: 0.2.1
   plotjuggler_ros:
     type: git
-    url: https://github.com/PlotJuggler/plotjuggler-ros-plugins
+    url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
     version: main
   pluginlib:
     type: git
@@ -417,7 +417,7 @@ repositories:
     version: kinetic-devel
   random_numbers:
     type: git
-    url: https://github.com/ros-planning/random_numbers
+    url: https://github.com/ros-planning/random_numbers.git
     version: master
   realsense_ros:
     type: git
@@ -429,7 +429,7 @@ repositories:
     version: melodic-devel
   resource_retriever:
     type: git
-    url: https://github.com/ros-o/resource_retriever
+    url: https://github.com/ros-o/resource_retriever.git
     version: obese-devel
   rgbd_launch:
     type: git
@@ -437,20 +437,12 @@ repositories:
     version: noetic-devel
   robot_state_publisher:
     type: git
-    url: https://github.com/ros-o/robot_state_publisher
+    url: https://github.com/ros-o/robot_state_publisher.git
     version: obese-devel
   ros:
     type: git
     url: https://github.com/ros/ros.git
     version: noetic-devel
-  rosauth:
-    type: git
-    url: https://github.com/GT-RAIL/rosauth.git
-    version: develop
-  rosbridge_suite:
-    type: git
-    url: https://github.com/RobotWebTools/rosbridge_suite.git
-    version: ros1
   ros_comm:
     type: git
     url: https://github.com/ubi-agni/ros_comm.git
@@ -465,7 +457,7 @@ repositories:
     version: obese-devel
   ros_controllers:
     type: git
-    url: https://github.com/ros-controls/ros_controllers
+    url: https://github.com/ros-controls/ros_controllers.git
     version: noetic-devel
   ros_environment:
     type: git
@@ -483,6 +475,10 @@ repositories:
     type: git
     url: https://github.com/ros-o/ros_type_introspection.git
     version: master
+  rosauth:
+    type: git
+    url: https://github.com/GT-RAIL/rosauth.git
+    version: develop
   rosbag_migration_rule:
     type: git
     url: https://github.com/ros/rosbag_migration_rule.git
@@ -491,6 +487,10 @@ repositories:
     type: git
     url: https://github.com/ros/rosbag_snapshot.git
     version: main
+  rosbridge_suite:
+    type: git
+    url: https://github.com/RobotWebTools/rosbridge_suite.git
+    version: ros1
   rosconsole:
     type: git
     url: https://github.com/ros-o/rosconsole.git
@@ -505,7 +505,7 @@ repositories:
     version: obese-devel
   rosdoc_lite:
     type: git
-    url: https://github.com/ros-infrastructure/rosdoc_lite
+    url: https://github.com/ros-infrastructure/rosdoc_lite.git
     version: master
   roslint:
     type: git
@@ -521,7 +521,7 @@ repositories:
     version: noetic-devel
   rosparam_shortcuts:
     type: git
-    url: https://github.com/ros-o/rosparam_shortcuts
+    url: https://github.com/ros-o/rosparam_shortcuts.git
     version: obese-devel
   rqt:
     type: git
@@ -681,11 +681,11 @@ repositories:
     version: master
   urdf:
     type: git
-    url: https://github.com/ros-o/urdf
+    url: https://github.com/ros-o/urdf.git
     version: obese-devel
   urdf_geometry_parser:
     type: git
-    url: https://github.com/ros-controls/urdf_geometry_parser
+    url: https://github.com/ros-controls/urdf_geometry_parser.git
     version: kinetic-devel
   urdf_sim_tutorial:
     type: git
@@ -701,7 +701,7 @@ repositories:
     version: melodic-devel
   vision_msgs:
     type: git
-    url: https://github.com/Kukanani/vision_msgs
+    url: https://github.com/Kukanani/vision_msgs.git
     version: noetic-devel
   vision_opencv:
     type: git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -7,10 +7,34 @@ repositories:
     type: git
     url: https://github.com/ros-o/Stage.git
     version: obese-devel
+  Universal_Robots_Client_Library:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+    version: master
+  Universal_Robots_ROS_Driver:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git
+    version: master
+  Universal_Robots_ROS_cartesian_control_msgs:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs.git
+    version: main
+  Universal_Robots_ROS_controllers_cartesian:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian.git
+    version: main
+  Universal_Robots_ROS_passthrough_controllers:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers.git
+    version: main
+  Universal_Robots_ROS_scaled_controllers:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers.git
+    version: main
   actionlib:
     type: git
-    url: https://github.com/rhaschke/actionlib.git
-    version: noetic-devel
+    url: https://github.com/ros-o/actionlib.git
+    version: obese-devel
   agni_tf_tools:
     type: git
     url: https://github.com/ubi-agni/agni_tf_tools.git
@@ -27,6 +51,10 @@ repositories:
     type: git
     url: https://github.com/ros/angles.git
     version: master
+  app_manager:
+    type: git
+    url: https://github.com/pr2/app_manager.git
+    version: kinetic-devel
   apriltag:
     type: git
     url: https://github.com/AprilRobotics/apriltag.git
@@ -39,6 +67,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/audio_common.git
     version: master
+  axis_camera:
+    type: git
+    url: https://github.com/ros-drivers/axis_camera.git
+    version: noetic-devel
   backward_ros:
     type: git
     url: https://github.com/pal-robotics/backward_ros.git
@@ -46,6 +78,10 @@ repositories:
   baldor:
     type: git
     url: https://github.com/crigroup/baldor.git
+    version: master
+  baxter_common:
+    type: git
+    url: https://github.com/RethinkRobotics/baxter_common.git
     version: master
   bio_ik:
     type: git
@@ -59,14 +95,26 @@ repositories:
     type: git
     url: https://github.com/ros-o/boost_sml.git
     version: obese-devel
+  calibration:
+    type: git
+    url: https://github.com/ros-o/calibration.git
+    version: obese-devel
+  camera_info_manager_py:
+    type: git
+    url: https://github.com/ros-o/camera_info_manager_py.git
+    version: obese-devel
   catkin:
     type: git
     url: https://github.com/ubi-agni/catkin.git
     version: noetic-devel
+  catkin_virtualenv:
+    type: git
+    url: https://github.com/locusrobotics/catkin_virtualenv.git
+    version: master
   class_loader:
     type: git
-    url: https://github.com/ros-o/class_loader.git
-    version: obese-devel
+    url: https://github.com/ros/class_loader.git
+    version: noetic-devel
   cmake_modules:
     type: git
     url: https://github.com/ros/cmake_modules.git
@@ -119,14 +167,18 @@ repositories:
     type: git
     url: https://github.com/ros/dynamic_reconfigure.git
     version: noetic-devel
+  dynamixel_motor:
+    type: git
+    url: https://github.com/arebgun/dynamixel_motor.git
+    version: master
   eigen_stl_containers:
     type: git
     url: https://github.com/ros/eigen_stl_containers.git
     version: master
   eigenpy:
-    type: tar
-    url: https://github.com/stack-of-tasks/eigenpy-ros-release/archive/release/noetic/eigenpy/2.9.2-1.tar.gz
-    version: eigenpy-ros-release-release-noetic-eigenpy-2.9.2-1
+    type: git
+    url: https://github.com/stack-of-tasks/eigenpy.git
+    version: master
   eml:
     type: git
     url: https://github.com/ros-o/eml.git
@@ -135,6 +187,10 @@ repositories:
     type: git
     url: https://github.com/shadow-robot/ethercat_grant.git
     version: noetic-devel
+  euslisp:
+    type: git
+    url: https://github.com/tork-a/euslisp-release.git
+    version: release/noetic/euslisp
   executive_smach:
     type: git
     url: https://github.com/ros/executive_smach.git
@@ -151,6 +207,10 @@ repositories:
     type: git
     url: https://github.com/flexible-collision-library/fcl.git
     version: 0.6.1
+  fetch_ros:
+    type: git
+    url: https://github.com/ros-o/fetch_ros.git
+    version: obese-devel
   filters:
     type: git
     url: https://github.com/ros/filters.git
@@ -197,7 +257,7 @@ repositories:
     version: main
   geometric_shapes:
     type: git
-    url: https://github.com/ros-planning/geometric_shapes.git
+    url: https://github.com/moveit/geometric_shapes.git
     version: noetic-devel
   geometry:
     type: git
@@ -210,7 +270,7 @@ repositories:
   geometry_tutorials:
     type: git
     url: https://github.com/ros/geometry_tutorials.git
-    version: kinetic-devel
+    version: noetic-devel
   gl_dependency:
     type: git
     url: https://github.com/ros-visualization/gl_dependency.git
@@ -231,6 +291,10 @@ repositories:
     type: git
     url: https://github.com/crigroup/handeye.git
     version: master
+  hpp-fcl:
+    type: git
+    url: https://github.com/humanoid-path-planner/hpp-fcl.git
+    version: devel
   image_common:
     type: git
     url: https://github.com/ros-perception/image_common.git
@@ -243,6 +307,14 @@ repositories:
     type: git
     url: https://github.com/ros-perception/image_transport_plugins.git
     version: noetic-devel
+  industrial_core:
+    type: git
+    url: https://github.com/ros-o/industrial_core.git
+    version: obese-devel
+  industrial_robot_status_controller:
+    type: git
+    url: https://github.com/gavanderhoorn/industrial_robot_status_controller.git
+    version: master
   interactive_markers:
     type: git
     url: https://github.com/ros-o/interactive_markers.git
@@ -259,6 +331,34 @@ repositories:
     type: git
     url: https://github.com/ros-o/joystick_drivers.git
     version: obese-devel
+  jsk_3rdparty:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
+    version: master
+  jsk_common:
+    type: git
+    url: https://github.com/ros-o/jsk_common.git
+    version: obese-devel
+  jsk_common_msgs:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+    version: master
+  jsk_recognition:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+    version: master
+  jsk_roseus:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_roseus.git
+    version: master
+  jsk_visualization:
+    type: git
+    url: https://github.com/ros-o/jsk_visualization.git
+    version: obese-devel
+  jskeus:
+    type: git
+    url: https://github.com/tork-a/jskeus-release.git
+    version: release/noetic/jskeus
   kdl_parser:
     type: git
     url: https://github.com/ros-o/kdl_parser.git
@@ -267,6 +367,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/laser_assembler.git
     version: noetic-devel
+  laser_filtering:
+    type: git
+    url: https://github.com/DLu/laser_filtering.git
+    version: noetic
   laser_filters:
     type: git
     url: https://github.com/ros-perception/laser_filters.git
@@ -279,14 +383,22 @@ repositories:
     type: git
     url: https://github.com/ros-perception/laser_pipeline.git
     version: noetic-devel
+  laser_proc:
+    type: git
+    url: https://github.com/ros-perception/laser_proc.git
+    version: noetic-devel
   libfranka:
     type: git
-    url: https://github.com/frankaemika/libfranka-release.git
-    version: release/noetic/libfranka/0.9.2-1
+    url: https://github.com/frankaemika/libfranka.git
+    version: main
   librealsense2:
     type: git
     url: https://github.com/ros-o/librealsense.git
     version: master
+  libuvc_ros:
+    type: git
+    url: https://github.com/ros-o/libuvc_ros.git
+    version: obese-devel
   media_export:
     type: git
     url: https://github.com/ros/media_export.git
@@ -303,33 +415,73 @@ repositories:
     type: git
     url: https://github.com/ros/metapackages.git
     version: noetic-devel
+  microstrain_3dmgx2_imu:
+    type: git
+    url: https://github.com/ros-drivers/microstrain_3dmgx2_imu.git
+    version: indigo-devel
+  ml_classifiers:
+    type: git
+    url: https://github.com/sniekum/ml_classifiers.git
+    version: master
+  mongodb_store:
+    type: git
+    url: https://github.com/ros-o/mongodb_store.git
+    version: obese-devel
   moveit:
     type: git
-    url: https://github.com/ubi-agni/moveit.git
+    url: https://github.com/moveit/moveit.git
     version: master
+  moveit_by_name:
+    type: git
+    url: https://github.com/TAMS-Group/moveit_by_name.git
+    version: main
   moveit_calibration:
     type: git
-    url: https://github.com/ros-o/moveit_calibration.git
+    url: https://github.com/moveit/moveit_calibration.git
     version: master
+  moveit_monitoring:
+    type: git
+    url: https://github.com/v4hn/moveit_monitoring.git
+    version: main
   moveit_msgs:
     type: git
-    url: https://github.com/ros-planning/moveit_msgs.git
+    url: https://github.com/moveit/moveit_msgs.git
     version: master
+  moveit_opw_kinematics_plugin:
+    type: git
+    url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
+    version: noetic-devel
+  moveit_python:
+    type: git
+    url: https://github.com/mikeferguson/moveit_python.git
+    version: ros1
   moveit_resources:
     type: git
-    url: https://github.com/ros-planning/moveit_resources.git
+    url: https://github.com/moveit/moveit_resources.git
     version: master
   moveit_task_constructor:
     type: git
-    url: https://github.com/ubi-agni/moveit_task_constructor.git
+    url: https://github.com/moveit/moveit_task_constructor.git
     version: master
   moveit_tutorials:
     type: git
-    url: https://github.com/ros-planning/moveit_tutorials.git
+    url: https://github.com/moveit/moveit_tutorials.git
     version: master
   moveit_visual_tools:
     type: git
-    url: https://github.com/rhaschke/moveit_visual_tools.git
+    url: https://github.com/moveit/moveit_visual_tools.git
+    version: noetic-devel
+  mtc_pour:
+    type: git
+    url: https://github.com/TAMS-Group/mtc_pour.git
+    version: master
+  multisense_ros:
+    type: git
+    url: https://github.com/ros-o/multisense_ros.git
+    version: obese-devel
+  navigation:
+    type: git
+    url: https://github.com/ros-planning/navigation.git
     version: noetic-devel
   navigation_msgs:
     type: git
@@ -342,35 +494,71 @@ repositories:
   object_recognition_msgs:
     type: git
     url: https://github.com/wg-perception/object_recognition_msgs.git
-    version: 0.4.2
+    version: noetic-devel
   octomap/octomap:
     type: tar
     url: https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.8-1.tar.gz
     version: octomap-release-release-noetic-octomap-1.9.8-1
+  octomap_mapping:
+    type: git
+    url: https://github.com/OctoMap/octomap_mapping.git
+    version: kinetic-devel
   octomap_msgs:
     type: git
     url: https://github.com/OctoMap/octomap_msgs.git
-    version: 0.3.5
+    version: melodic-devel
+  octomap_ros:
+    type: git
+    url: https://github.com/OctoMap/octomap_ros.git
+    version: melodic-devel
   ompl:
     type: git
-    url: https://github.com/ros-gbp/ompl-release.git
-    version: release/noetic/ompl/1.6.0-1
+    url: https://github.com/ompl/ompl.git
+    version: main
+  open_karto:
+    type: git
+    url: https://github.com/ros-perception/open_karto.git
+    version: melodic-devel
+  openni2_camera:
+    type: git
+    url: https://github.com/ros-o/openni2_camera.git
+    version: obese-devel
+  openni_camera:
+    type: git
+    url: https://github.com/ros-o/openni_camera.git
+    version: obese-devel
+  openslam_gmapping:
+    type: git
+    url: https://github.com/ros-perception/openslam_gmapping.git
+    version: melodic-devel
+  opw_kinematics:
+    type: git
+    url: https://github.com/Jmeyer1292/opw_kinematics.git
+    version: master
   pal_statistics:
     type: git
     url: https://github.com/pal-robotics/pal_statistics.git
     version: kinetic-devel
   panda_moveit_config:
     type: git
-    url: https://github.com/ros-planning/panda_moveit_config.git
+    url: https://github.com/moveit/panda_moveit_config.git
     version: noetic-devel
   pcl_msgs:
     type: git
     url: https://github.com/ros-perception/pcl_msgs.git
     version: noetic-devel
+  people:
+    type: git
+    url: https://github.com/ros-o/people.git
+    version: obese-devel
   perception_pcl:
     type: git
     url: https://github.com/ros-o/perception_pcl.git
     version: obese-devel
+  pinocchio:
+    type: git
+    url: https://github.com/stack-of-tasks/pinocchio.git
+    version: master
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git
@@ -391,33 +579,73 @@ repositories:
     type: git
     url: https://github.com/pr2/pr2_common.git
     version: melodic-devel
+  pr2_controllers:
+    type: git
+    url: https://github.com/pr2/pr2_controllers.git
+    version: melodic-devel
+  pr2_ethercat_drivers:
+    type: git
+    url: https://github.com/pr2/pr2_ethercat_drivers.git
+    version: kinetic-devel
   pr2_kinematics:
     type: git
-    url: https://github.com/ros-o/pr2_kinematics.git
+    url: https://github.com/PR2/pr2_kinematics.git
+    version: noetic-devel
+  pr2_mechanism:
+    type: git
+    url: https://github.com/pr2/pr2_mechanism.git
+    version: melodic-devel
+  pr2_mechanism_msgs:
+    type: git
+    url: https://github.com/pr2/pr2_mechanism_msgs.git
+    version: master
+  pr2_power_drivers:
+    type: git
+    url: https://github.com/pr2/pr2_power_drivers.git
+    version: kinetic-devel
+  pr2_robot:
+    type: git
+    url: https://github.com/pr2/pr2_robot.git
+    version: kinetic-devel
+  prosilica_driver:
+    type: git
+    url: https://github.com/ros-o/prosilica_driver.git
     version: obese-devel
+  prosilica_gige_sdk:
+    type: git
+    url: https://github.com/ros-drivers/prosilica_gige_sdk.git
+    version: hydro-devel
   py_binding_tools:
     type: git
-    url: https://github.com/ros-planning/py_binding_tools.git
+    url: https://github.com/moveit/py_binding_tools.git
     version: main
   pybind11_catkin:
     type: git
     url: https://github.com/wxmerkt/pybind11_catkin.git
-    version: 2.10.3
+    version: master
   python_qt_binding:
     type: git
-    url: https://github.com/ros-o/python_qt_binding.git
+    url: https://github.com/v4hn/python_qt_binding.git
+    version: pr-obese-sip5
+  qbdevice-ros:
+    type: git
+    url: https://github.com/ros-o/qbdevice-ros.git
+    version: obese-devel
+  qbhand-ros:
+    type: git
+    url: https://github.com/ros-o/qbhand-ros.git
     version: obese-devel
   qt_gui_core:
     type: git
-    url: https://github.com/ros-o/qt_gui_core.git
-    version: obese-devel
+    url: https://github.com/v4hn/qt_gui_core.git
+    version: pr-obese-sip5
   qwt_dependency:
     type: git
     url: https://github.com/ros-visualization/qwt_dependency.git
     version: kinetic-devel
   random_numbers:
     type: git
-    url: https://github.com/ros-planning/random_numbers.git
+    url: https://github.com/moveit/random_numbers.git
     version: master
   realsense_ros:
     type: git
@@ -435,6 +663,22 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/rgbd_launch.git
     version: noetic-devel
+  robot_body_filter:
+    type: git
+    url: https://github.com/peci1/robot_body_filter.git
+    version: master
+  robot_calibration:
+    type: git
+    url: https://github.com/mikeferguson/robot_calibration.git
+    version: ros1
+  robot_pose_ekf:
+    type: git
+    url: https://github.com/ros-planning/robot_pose_ekf.git
+    version: master
+  robot_self_filter:
+    type: git
+    url: https://github.com/PR2/robot_self_filter.git
+    version: indigo-devel
   robot_state_publisher:
     type: git
     url: https://github.com/ros-o/robot_state_publisher.git
@@ -445,7 +689,7 @@ repositories:
     version: noetic-devel
   ros_comm:
     type: git
-    url: https://github.com/ubi-agni/ros_comm.git
+    url: https://github.com/ros-o/ros_comm.git
     version: obese-devel
   ros_comm_msgs:
     type: git
@@ -453,20 +697,40 @@ repositories:
     version: kinetic-devel
   ros_control:
     type: git
-    url: https://github.com/ros-o/ros_control.git
+    url: https://github.com/ros-controls/ros_control.git
+    version: noetic-devel
+  ros_control_boilerplate:
+    type: git
+    url: https://github.com/ros-o/ros_control_boilerplate.git
     version: obese-devel
   ros_controllers:
     type: git
     url: https://github.com/ros-controls/ros_controllers.git
     version: noetic-devel
+  ros_emacs_utils:
+    type: git
+    url: https://github.com/code-iai/ros_emacs_utils.git
+    version: master
   ros_environment:
     type: git
     url: https://github.com/ros-o/ros_environment.git
     version: 348f78c92113ccb809ced887f7856a66f84f63ea
+  ros_industrial_cmake_boilerplate:
+    type: git
+    url: https://github.com/ros-industrial/ros_industrial_cmake_boilerplate.git
+    version: master
+  ros_numpy:
+    type: git
+    url: https://github.com/ros-o/ros_numpy.git
+    version: obese-devel
   ros_pytest:
     type: git
     url: https://github.com/machinekoder/ros_pytest.git
     version: noetic-devel
+  ros_realtime:
+    type: git
+    url: https://github.com/ros-o/ros_realtime.git
+    version: obese-devel
   ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
@@ -547,6 +811,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt_dep.git
     version: master
+  rqt_ez_publisher:
+    type: git
+    url: https://github.com/OTL/rqt_ez_publisher.git
+    version: noetic-devel
   rqt_graph:
     type: git
     url: https://github.com/ros-visualization/rqt_graph.git
@@ -555,6 +823,10 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/rqt_image_view.git
     version: master
+  rqt_joint_trajectory_plot:
+    type: git
+    url: https://github.com/ros-o/rqt_joint_trajectory_plot.git
+    version: obese-devel
   rqt_launch:
     type: git
     url: https://github.com/ros-visualization/rqt_launch.git
@@ -648,9 +920,9 @@ repositories:
     url: https://github.com/ros-visualization/rqt_web.git
     version: master
   ruckig:
-    type: tar
-    url: https://github.com/pantor/ruckig-release/archive/release/noetic/ruckig/0.9.2-1.tar.gz
-    version: ruckig-release-release-noetic-ruckig-0.9.2-1
+    type: git
+    url: https://github.com/pantor/ruckig.git
+    version: main
   rviz:
     type: git
     url: https://github.com/ros-visualization/rviz.git
@@ -659,9 +931,25 @@ repositories:
     type: git
     url: https://github.com/ros-o/rviz_visual_tools.git
     version: obese-devel
+  slam_gmapping:
+    type: git
+    url: https://github.com/ros-perception/slam_gmapping.git
+    version: melodic-devel
+  slam_karto:
+    type: git
+    url: https://github.com/ros-o/slam_karto.git
+    version: obese-devel
+  soem:
+    type: git
+    url: https://github.com/mgruhler/soem.git
+    version: melodic
+  sparse_bundle_adjustment:
+    type: git
+    url: https://github.com/ros-perception/sparse_bundle_adjustment.git
+    version: melodic-devel
   srdfdom:
     type: git
-    url: https://github.com/ros-planning/srdfdom.git
+    url: https://github.com/moveit/srdfdom.git
     version: noetic-devel
   stage_ros:
     type: git
@@ -679,6 +967,18 @@ repositories:
     type: git
     url: https://github.com/ros-teleop/teleop_twist_keyboard.git
     version: master
+  trac_ik:
+    type: git
+    url: https://github.com/ros-o/trac_ik.git
+    version: obese-devel
+  universal_robot:
+    type: git
+    url: https://github.com/ros-industrial/universal_robot.git
+    version: noetic-devel
+  ur_msgs:
+    type: git
+    url: https://github.com/ros-industrial/ur_msgs.git
+    version: noetic-devel
   urdf:
     type: git
     url: https://github.com/ros-o/urdf.git
@@ -699,6 +999,22 @@ repositories:
     type: git
     url: https://github.com/ros/urdf_parser_py.git
     version: melodic-devel
+  urg_c:
+    type: git
+    url: https://github.com/ros-drivers/urg_c.git
+    version: master
+  urg_node:
+    type: git
+    url: https://github.com/ros-o/urg_node.git
+    version: obese-devel
+  usb_cam:
+    type: git
+    url: https://github.com/ros-drivers/usb_cam.git
+    version: develop
+  view_controller_msgs:
+    type: git
+    url: https://github.com/ros-visualization/view_controller_msgs.git
+    version: noetic-devel
   vision_msgs:
     type: git
     url: https://github.com/Kukanani/vision_msgs.git
@@ -713,16 +1029,32 @@ repositories:
     version: obese-devel
   warehouse_ros:
     type: git
-    url: https://github.com/ros-planning/warehouse_ros.git
+    url: https://github.com/moveit/warehouse_ros.git
     version: kinetic-devel
+  warehouse_ros_mongo:
+    type: git
+    url: https://github.com/moveit/warehouse_ros_mongo.git
+    version: noetic-devel
   warehouse_ros_sqlite:
     type: git
-    url: https://github.com/ros-planning/warehouse_ros_sqlite.git
+    url: https://github.com/moveit/warehouse_ros_sqlite.git
     version: master
   webkit_dependency:
     type: git
     url: https://github.com/ros-visualization/webkit_dependency.git
     version: kinetic-devel
+  wge100_driver:
+    type: git
+    url: https://github.com/ros-o/wge100_driver.git
+    version: obese-devel
+  wifi_ddwrt:
+    type: git
+    url: https://github.com/ros-drivers/wifi_ddwrt.git
+    version: noetic-devel
+  wu_ros_tools:
+    type: git
+    url: https://github.com/DLu/wu_ros_tools.git
+    version: noetic
   xacro:
     type: git
     url: https://github.com/ros/xacro.git

--- a/src/build.sh
+++ b/src/build.sh
@@ -137,7 +137,7 @@ function pkg_exists {
   local pkg_version="${2%"$DEB_DISTRO"}"
   local available; available=$(LANG=C apt-cache policy "$1" | sed -n "s#^\s*Candidate:\s\(.*\)$DEB_DISTRO\..*#\1#p")
   if [ "$SKIP_EXISTING" == "true" ] && [ -n "$available" ] && [ "$available" != "(none)" ] && \
-     dpkg --compare-versions "$available" ">=" "$pkg_version"; then
+     dpkg --compare-versions "$available" ">=" "$pkg_version" && ! "$SRC_PATH/scripts/upstream_rebuilds.py" "$DEBS_PATH"; then
     echo "Skipped (existing version $available >= $pkg_version)"
     return 0
   fi

--- a/src/scripts/upstream_rebuilds.py
+++ b/src/scripts/upstream_rebuilds.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from catkin_pkg.package import _get_package_xml, parse_package_string
+from rosdep2.main import (
+    _get_default_RosdepLookup,
+    create_default_installer_context,
+    configure_installer_context,
+    get_default_installer,
+)
+from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY
+from rosdep2.sources_list import get_sources_cache_dir
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import os, sys
+
+
+@dataclass
+class Options:
+    as_root: dict = field(default_factory=lambda: {})
+    dependency_types: list[str] = field(default_factory=lambda: [])
+    os_override: str = None
+    sources_cache_dir: str = get_sources_cache_dir()
+    verbose: bool = False
+
+
+debs = Path(sys.argv[1])
+folder = Path(sys.argv[2] if len(sys.argv) > 2 else ".")
+
+xml, file = _get_package_xml(folder)
+pkg = parse_package_string(xml, filename=file)
+pkg.evaluate_conditions(os.environ)
+
+options = Options()
+lookup = _get_default_RosdepLookup(options)
+installer_context = create_default_installer_context(verbose=options.verbose)
+configure_installer_context(installer_context, options)
+
+installer, installer_keys, default_key, os_name, os_version = get_default_installer(
+    installer_context=installer_context, verbose=options.verbose
+)
+
+view = lookup.get_rosdep_view(DEFAULT_VIEW_KEY, verbose=options.verbose)
+
+
+def resolve(rosdep_name):
+    "Resolve rosdep package name to required system package name(s)"
+    try:
+        d = view.lookup(rosdep_name)
+    except KeyError:
+        return []
+
+    rule_installer, rule = d.get_rule_for_platform(
+        os_name, os_version, installer_keys, default_key
+    )
+
+    installer = installer_context.get_installer(rule_installer)
+    resolved = installer.resolve(rule)
+    return resolved
+
+
+for dep in pkg.build_depends:
+    if dep.evaluated_condition:
+        for name in resolve(dep.name):
+            # check whether file debs/name*.deb exists
+            if any(debs.glob(f"{name}*.deb")):
+                print(f"Rebuild needed due to {name}")
+                exit(0)  # rebuild needed
+
+exit(1)  # no rebuild needed


### PR DESCRIPTION
As discussed before, here is the patch for the in total 1009 packages building successfully for jammy in https://github.com/v4hn/ros-o-builder/blob/jammy-one/README.md

For the debian-based builds I use [these additional rosdep keys](https://github.com/v4hn/ros-o-builder/blob/build-for-jammy/rosdep.yaml) for now.
I don't know how many of these you will need as well, if any, as most just remap to native debian packages.

https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/509 lists the remaining few failures in the JSK stack.
I would still prefer to keep the JSK repositories included here because jsk_visualization (with rviz and qt plugins) builds and has cross-references with the other repositories.

Please look through the individual entries to decide on a case-by-case basis whether you also want to, e.g., use upstream for ruckig and ompl instead of the release versions.

I would appreciate it if we can keep the `.git` suffix consistently to ease future merge efforts.