### PR TITLE
Use os-release's "VERSION_CODENAME" to populate the right distro name in the apt source list

### DIFF
--- a/.github/docker/ros-core/Dockerfile
+++ b/.github/docker/ros-core/Dockerfile
@@ -18,8 +18,9 @@ RUN apt-get update && apt-get install -q -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # setup sources.list
-RUN curl -sSL https://ros.packages.techfak.net/gpg.key -o /etc/apt/keyrings/ros-one-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net jammy main" | tee /etc/apt/sources.list.d/ros1.list
+RUN curl -sSL https://ros.packages.techfak.net/gpg.key -o /etc/apt/keyrings/ros-one-keyring.gpg \
+    && . /etc/os-release \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net $VERSION_CODENAME main" | tee /etc/apt/sources.list.d/ros1.list
 
 # setup environment
 ENV LANG=C.UTF-8


### PR DESCRIPTION
This allows to build images for Ubuntu 24.04 by passing `--build-arg DEB_DISTRO=noble`

---

Without this change building with `--build-arg noble` results in:
```
3.972 The following packages have unmet dependencies:
4.025  ros-one-rosbag : Depends: libboost-regex1.74.0-icu70 but it is not installable
4.025                   Depends: ros-one-rosbag-storage but it is not going to be installed
4.025  ros-one-rosconsole : Depends: libboost-regex1.74.0-icu70 but it is not installable
4.025                       Depends: liblog4cxx12 (>= 0.12.1) but it is not installable
4.025  ros-one-rospack : Depends: libpython3.10 (>= 3.10.0) but it is not installable
4.025                    Depends: libtinyxml2-9 (>= 8.0.0) but it is not installable
4.026 E: Unable to correct problems, you have held broken packages.
------
Dockerfile:31
--------------------
  30 |     # install ros packages
  31 | >>> RUN apt-get update && apt-get install -y --no-install-recommends \
  32 | >>>     ros-one-ros-core \
  33 | >>>     && rm -rf /var/lib/apt/lists/*
  34 |     
--------------------
```