### PR TITLE
use catkin from ros-o rather than custom fork

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -105,8 +105,8 @@ repositories:
     version: obese-devel
   catkin:
     type: git
-    url: https://github.com/ubi-agni/catkin.git
-    version: noetic-devel
+    url: https://github.com/ros-o/catkin.git
+    version: obese-devel
   catkin_virtualenv:
     type: git
     url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Looks like the ros-o one is up to date and has all the patches that are in the ubi-agni fork.
Is it preferred to use the ros-o repos by default ?

https://github.com/ros-o/catkin/commits/obese-devel/
https://github.com/ubi-agni/catkin/commits/noetic-devel/