### PR TITLE
Add ros-perception/opencv_apps to ros-one.repos

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -519,6 +519,10 @@ repositories:
     type: git
     url: https://github.com/ros-perception/open_karto.git
     version: melodic-devel
+  opencv_apps:
+    type: git
+    url: https://github.com/ros-perception/opencv_apps.git
+    version: indigo
   openni2_camera:
     type: git
     url: https://github.com/ros-o/openni2_camera.git


### PR DESCRIPTION
The `opencv_apps` package provides ROS nodes/nodelets wrapping OpenCV algorithms for image processing