### PR TITLE
Follow master branch for CogRob/catkin_grpc

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -110,7 +110,7 @@ repositories:
   catkin_grpc:
     type: git
     url: https://github.com/CogRob/catkin_grpc.git
-    version: 0.0.16
+    version: master
   catkin_virtualenv:
     type: git
     url: https://github.com/locusrobotics/catkin_virtualenv.git


### PR DESCRIPTION
Because packages are built differentially, I thought it would be better to specify the latest branch instead of pinning the specific version.