### PR TITLE
Include some jsk packages

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -63,6 +63,10 @@ repositories:
     type: git
     url: https://github.com/AprilRobotics/apriltag_ros.git
     version: master
+  ar_track_alvar:
+    type: git
+    url: https://github.com/ros-o/ar_track_alvar.git
+    version: obese-devel
   audio_common:
     type: git
     url: https://github.com/ros-drivers/audio_common.git
@@ -103,6 +107,10 @@ repositories:
     type: git
     url: https://github.com/ros-o/camera_info_manager_py.git
     version: obese-devel
+  camera_umd:
+    type: git
+    url: https://github.com/ros-drivers/camera_umd.git
+    version: master
   catkin:
     type: git
     url: https://github.com/ros-o/catkin.git
@@ -191,10 +199,6 @@ repositories:
     type: git
     url: https://github.com/ros-o/ethercat_grant.git
     version: obese-devel
-  euslisp:
-    type: git
-    url: https://github.com/tork-a/euslisp-release.git
-    version: release/noetic/euslisp
   executive_smach:
     type: git
     url: https://github.com/ros/executive_smach.git
@@ -259,6 +263,10 @@ repositories:
     type: git
     url: https://github.com/ros/genpy.git
     version: main
+  geographic_info:
+    type: git
+    url: https://github.com/ros-geographic-info/geographic_info.git
+    version: master
   geometric_shapes:
     type: git
     url: https://github.com/moveit/geometric_shapes.git
@@ -341,11 +349,19 @@ repositories:
     version: master
   jsk_common:
     type: git
-    url: https://github.com/ros-o/jsk_common.git
-    version: obese-devel
+    url: https://github.com/jsk-ros-pkg/jsk_common.git
+    version: master
   jsk_common_msgs:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
+    version: master
+  jsk_model_tools:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
+    version: master
+  jsk_pr2eus:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
     version: master
   jsk_recognition:
     type: git
@@ -357,12 +373,8 @@ repositories:
     version: master
   jsk_visualization:
     type: git
-    url: https://github.com/ros-o/jsk_visualization.git
-    version: obese-devel
-  jskeus:
-    type: git
-    url: https://github.com/tork-a/jskeus-release.git
-    version: release/noetic/jskeus
+    url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+    version: master
   kdl_parser:
     type: git
     url: https://github.com/ros-o/kdl_parser.git
@@ -427,6 +439,10 @@ repositories:
     type: git
     url: https://github.com/sniekum/ml_classifiers.git
     version: master
+  mocap_optitrack:
+    type: git
+    url: https://github.com/ros-o/mocap_optitrack.git
+    version: obese-devel
   mongodb_store:
     type: git
     url: https://github.com/ros-o/mongodb_store.git
@@ -455,6 +471,10 @@ repositories:
     type: git
     url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
     version: noetic-devel
+  moveit_pr2:
+    type: git
+    url: https://github.com/moveit/moveit_pr2.git
+    version: obese-devel
   moveit_python:
     type: git
     url: https://github.com/mikeferguson/moveit_python.git
@@ -491,6 +511,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
     version: ros1
+  openslam_gmapping:
+    type: git
+    url: https://github.com/ros-perception/openslam_gmapping.git
+    version: melodic-devel
   nodelet_core:
     type: git
     url: https://github.com/ros/nodelet_core.git
@@ -579,10 +603,18 @@ repositories:
     type: git
     url: https://github.com/ros-o/pluginlib.git
     version: obese-devel
+  pr2_apps:
+    type: git
+    url: https://github.com/pr2/pr2_apps.git
+    version: melodic-devel
   pr2_common:
     type: git
     url: https://github.com/pr2/pr2_common.git
     version: melodic-devel
+  pr2_common_actions:
+    type: git
+    url: https://github.com/pr2/pr2_common_actions.git
+    version: kinetic-devel
   pr2_controllers:
     type: git
     url: https://github.com/pr2/pr2_controllers.git
@@ -603,6 +635,10 @@ repositories:
     type: git
     url: https://github.com/pr2/pr2_mechanism_msgs.git
     version: master
+  pr2_navigation:
+    type: git
+    url: https://github.com/pr2/pr2_navigation.git
+    version: kinetic-devel
   pr2_power_drivers:
     type: git
     url: https://github.com/pr2/pr2_power_drivers.git
@@ -610,6 +646,10 @@ repositories:
   pr2_robot:
     type: git
     url: https://github.com/pr2/pr2_robot.git
+    version: kinetic-devel
+  pr2_simulator:
+    type: git
+    url: https://github.com/PR2/pr2_simulator.git
     version: kinetic-devel
   prosilica_driver:
     type: git
@@ -659,6 +699,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
     version: melodic-devel
+  realtime_urdf_filter:
+    type: git
+    url: https://github.com/blodow/realtime_urdf_filter.git
+    version: master
   resource_retriever:
     type: git
     url: https://github.com/ros-o/resource_retriever.git
@@ -930,7 +974,7 @@ repositories:
   ruckig:
     type: git
     url: https://github.com/pantor/ruckig.git
-    version: v0.14.0
+    version: main
   rviz:
     type: git
     url: https://github.com/ros-visualization/rviz.git
@@ -1019,6 +1063,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/usb_cam.git
     version: develop
+  unique_identifier:
+    type: git
+    url: https://github.com/ros-geographic-info/unique_identifier.git
+    version: master
   view_controller_msgs:
     type: git
     url: https://github.com/ros-visualization/view_controller_msgs.git
@@ -1059,6 +1107,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/wifi_ddwrt.git
     version: noetic-devel
+  willow_maps:
+    type: git
+    url: https://github.com/pr2/willow_maps.git
+    version: kinetic-devel
   wu_ros_tools:
     type: git
     url: https://github.com/DLu/wu_ros_tools.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -371,10 +371,10 @@ repositories:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git
     version: master
-  jsk_visualization:
-    type: git
-    url: https://github.com/jsk-ros-pkg/jsk_visualization.git
-    version: master
+  # jsk_visualization:
+  #   type: git
+  #   url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+  #   version: master
   kdl_parser:
     type: git
     url: https://github.com/ros-o/kdl_parser.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -363,10 +363,10 @@ repositories:
   #   type: git
   #   url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
   #   version: master
-  # jsk_recognition:
-  #   type: git
-  #   url: https://github.com/jsk-ros-pkg/jsk_recognition.git
-  #   version: master
+  jsk_recognition:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+    version: master
   jsk_roseus:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git
@@ -1128,10 +1128,7 @@ sbuild_options:
 known_failures:
   "*/*":
     - jsk_3rdparty/*
-    - jsk_common/jsk_data
-    - jsk_common/jsk_ros_patch/multi_map_server
     - jsk_visualization/*
-    - jsk_recognition/*
     - jsk_roseus/roseus_tutorials
     - pr2_robot/imu_monitor
   "*/jammy":

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -373,8 +373,8 @@ repositories:
     version: master
   jsk_visualization:
     type: git
-    url: https://github.com/jsk-ros-pkg/jsk_visualization.git
-    version: master
+    url: https://github.com/ros-o/jsk_visualization.git
+    version: obese-devel
   kdl_parser:
     type: git
     url: https://github.com/ros-o/kdl_parser.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -349,16 +349,16 @@ repositories:
     version: master
   jsk_common:
     type: git
-    url: https://github.com/mqcmd196/jsk_common.git
-    version: techfak-ros-o
+    url: https://github.com/ros-o/jsk_common.git
+    version: obese-devel
   jsk_common_msgs:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
     version: master
   jsk_model_tools:
     type: git
-    url: https://github.com/mqcmd196/jsk_model_tools.git
-    version: techfak-ros-o
+    url: https://github.com/ros-o/jsk_model_tools.git
+    version: obese-devel
   # jsk_pr2eus:
   #   type: git
   #   url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -359,14 +359,14 @@ repositories:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
     version: master
-  jsk_pr2eus:
-    type: git
-    url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-    version: master
-  jsk_recognition:
-    type: git
-    url: https://github.com/jsk-ros-pkg/jsk_recognition.git
-    version: master
+  # jsk_pr2eus:
+  #   type: git
+  #   url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+  #   version: master
+  # jsk_recognition:
+  #   type: git
+  #   url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+  #   version: master
   jsk_roseus:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -1128,8 +1128,6 @@ sbuild_options:
 known_failures:
   "*/*":
     - jsk_3rdparty/*
-    - jsk_visualization/*
-    - jsk_roseus/roseus_tutorials
     - pr2_robot/imu_monitor
   "*/jammy":
   "*/noble":

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -349,7 +349,7 @@ repositories:
     version: master
   jsk_common:
     type: git
-    url: https://github.com/jsk-ros-pkg/jsk_common.git
+    url: https://github.com/mqcmd196/jsk_common.git
     version: techfak-ros-o
   jsk_common_msgs:
     type: git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -613,8 +613,8 @@ repositories:
     version: melodic-devel
   pr2_common_actions:
     type: git
-    url: https://github.com/pr2/pr2_common_actions.git
-    version: kinetic-devel
+    url: https://github.com/mqcmd196/pr2_common_actions.git
+    version: ros-o
   pr2_controllers:
     type: git
     url: https://github.com/pr2/pr2_controllers.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -473,7 +473,7 @@ repositories:
     version: noetic-devel
   moveit_pr2:
     type: git
-    url: https://github.com/moveit/moveit_pr2.git
+    url: https://github.com/mqcmd196/moveit_pr2.git
     version: obese-devel
   moveit_python:
     type: git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -365,15 +365,15 @@ repositories:
     version: master
   jsk_recognition:
     type: git
-    url: https://github.com/jsk-ros-pkg/jsk_recognition.git
-    version: master
+    url: https://github.com/ros-o/jsk_recognition.git
+    version: obese-devel
   jsk_roseus:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git
     version: master
   jsk_visualization:
     type: git
-    url: https://github.com/ros-o/jsk_visualization.git
+    url: https://github.com/jsk-ros-pkg/jsk_visualization.git
     version: obese-devel
   kdl_parser:
     type: git
@@ -1129,6 +1129,7 @@ known_failures:
   "*/*":
     - jsk_3rdparty/*
     - pr2_robot/imu_monitor
+    - jsk_pr2eus/pr2eus_tutorials # skip because jsk_maps is not released
   "*/jammy":
   "*/noble":
     - librealsense2

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -357,8 +357,8 @@ repositories:
     version: master
   jsk_model_tools:
     type: git
-    url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
-    version: master
+    url: https://github.com/mqcmd196/jsk_model_tools.git
+    version: techfak-ros-o
   # jsk_pr2eus:
   #   type: git
   #   url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -473,7 +473,7 @@ repositories:
     version: noetic-devel
   moveit_pr2:
     type: git
-    url: https://github.com/mqcmd196/moveit_pr2.git
+    url: https://github.com/ros-o/moveit_pr2.git
     version: obese-devel
   moveit_python:
     type: git
@@ -613,8 +613,8 @@ repositories:
     version: melodic-devel
   pr2_common_actions:
     type: git
-    url: https://github.com/mqcmd196/pr2_common_actions.git
-    version: ros-o
+    url: https://github.com/ros-o/pr2_common_actions.git
+    version: obese-devel
   pr2_controllers:
     type: git
     url: https://github.com/pr2/pr2_controllers.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -350,7 +350,7 @@ repositories:
   jsk_common:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_common.git
-    version: master
+    version: techfak-ros-o
   jsk_common_msgs:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -359,10 +359,10 @@ repositories:
     type: git
     url: https://github.com/ros-o/jsk_model_tools.git
     version: obese-devel
-  # jsk_pr2eus:
-  #   type: git
-  #   url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-  #   version: master
+  jsk_pr2eus:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+    version: master
   jsk_recognition:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_recognition.git
@@ -371,10 +371,10 @@ repositories:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git
     version: master
-  # jsk_visualization:
-  #   type: git
-  #   url: https://github.com/jsk-ros-pkg/jsk_visualization.git
-  #   version: master
+  jsk_visualization:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+    version: master
   kdl_parser:
     type: git
     url: https://github.com/ros-o/kdl_parser.git

--- a/rosdep.yaml
+++ b/rosdep.yaml
@@ -47,3 +47,10 @@ orocos_kdl: # needed for robot_calibration, pr2_head_action, ...
 bfl: # needed for robot_pose_ekf
   debian: [liborocos-bfl-dev]
   ubuntu: [liborocos-bfl-dev]
+
+euslisp:
+  debian: [euslisp-dev]
+  ubuntu: [euslisp-dev]
+jskeus:
+  debian: [jskeus-dev]
+  ubuntu: [jskeus-dev]

--- a/rosdep.yaml
+++ b/rosdep.yaml
@@ -48,6 +48,10 @@ bfl: # needed for robot_pose_ekf
   debian: [liborocos-bfl-dev]
   ubuntu: [liborocos-bfl-dev]
 
+python3-freezegun:
+  debian: [python3-freezegun]
+  ubuntu: [python3-freezegun]
+
 euslisp:
   debian: [euslisp-dev]
   ubuntu: [euslisp-dev]

--- a/rosdep.yaml
+++ b/rosdep.yaml
@@ -48,10 +48,6 @@ bfl: # needed for robot_pose_ekf
   debian: [liborocos-bfl-dev]
   ubuntu: [liborocos-bfl-dev]
 
-python3-freezegun:
-  debian: [python3-freezegun]
-  ubuntu: [python3-freezegun]
-
 euslisp:
   debian: [euslisp-dev]
   ubuntu: [euslisp-dev]


### PR DESCRIPTION
This PR adds some JSK packages. I don't add all JSK packages this time, but I add common ones.

- `eusurdf` and `ros-one-pr2-gazebo-plugins` are expected to fail on jammy/arm64, noble/* because gazebo is not released
- ignoring the package which uses `catkin_virtualenv` because of the error:
```
+------------------------------------------------------------------------------+
  | Build                                                                        |
  +------------------------------------------------------------------------------+
  
  
  Unpack source
  -------------
  
  Format: 1.0
  Source: ros-one-jsk-rosbag-tools
  Binary: ros-one-jsk-rosbag-tools
  Architecture: any
  Version: 2.2.16-2jammy.20250322.0050
  Maintainer: Iori Yanokura <yanokura@jsk.imi.i.u-tokyo.ac.jp>
  Standards-Version: 3.9.2
  Build-Depends: debhelper (>= 9.0.0), python3-catkin-pkg-modules, ros-one-catkin, ros-one-catkin-virtualenv (>= 0.5.1), ros-one-roslint <!nocheck>, ros-one-rostest <!nocheck>
  Package-List:
   ros-one-jsk-rosbag-tools deb misc optional arch=any
  Checksums-Sha1:
   8619e494bda55ed6f51186725afaf0756f4fdf77 25644 ros-one-jsk-rosbag-tools_2.2.16-2jammy.20250322.0050.tar.gz
  Checksums-Sha256:
   d8ba69e8c1a4cd418382b534034102dfb7deae416e60561c083da807a5f3b3e3 25644 ros-one-jsk-rosbag-tools_2.2.16-2jammy.20250322.0050.tar.gz
  Files:
   e65aaa2742845e9a2d3158d70726d55d 25644 ros-one-jsk-rosbag-tools_2.2.16-2jammy.20250322.0050.tar.gz
  
  dpkg-source: warning: extracting unsigned source package (ros-one-jsk-rosbag-tools_2.2.16-2jammy.20250322.0050.dsc)
  dpkg-source: info: extracting ros-one-jsk-rosbag-tools in /<<BUILDDIR>>package
  dpkg-source: info: unpacking ros-one-jsk-rosbag-tools_2.2.16-2jammy.20250322.0050.tar.gz
  
  Check disk space
  ----------------
  
  Sufficient free space for build
  
  User Environment
  ----------------
  
  APT_CONFIG=/var/lib/sbuild/apt.conf
  CCACHE_DIR=/build/ccache
  DEB_BUILD_OPTIONS=nocheck
  HOME=/sbuild-nonexistent
  LANG=C.UTF-8
  LC_ALL=C.UTF-8
  LOGNAME=runner
  PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
  SCHROOT_ALIAS_NAME=sbuild
  SCHROOT_CHROOT_NAME=sbuild
  SCHROOT_COMMAND=env
  SCHROOT_GID=128
  SCHROOT_GROUP=docker
  SCHROOT_SESSION_ID=sbuild-8e606e16-5599-4a89-a96a-acb00ed60076
  SCHROOT_UID=1001
  SCHROOT_USER=runner
  SHELL=/bin/sh
  USER=runner
  
  dpkg-buildpackage
  -----------------
  
  Command: dpkg-buildpackage --sanitize-env -us -uc -b -rfakeroot
  dpkg-buildpackage: info: source package ros-one-jsk-rosbag-tools
  dpkg-buildpackage: info: source version 2.2.16-2jammy.20250322.0050
  dpkg-buildpackage: info: source distribution UNRELEASED
  dpkg-buildpackage: info: source changed by Iori Yanokura <yanokura@jsk.imi.i.u-tokyo.ac.jp>
   dpkg-source --before-build .
  dpkg-buildpackage: info: host architecture amd64
  dpkg-source: info: using options from package/debian/source/options: --auto-commit
   fakeroot debian/rules clean
  dh clean -v --buildsystem=cmake --builddirectory=.obj-x86_64-linux-gnu
     dh_auto_clean -O-v -O--buildsystem=cmake -O--builddirectory=.obj-x86_64-linux-gnu
     dh_autoreconf_clean -O-v -O--buildsystem=cmake -O--builddirectory=.obj-x86_64-linux-gnu
     dh_clean -O-v -O--buildsystem=cmake -O--builddirectory=.obj-x86_64-linux-gnu
  	rm -f debian/debhelper-build-stamp
  	rm -rf debian/.debhelper/
  	rm -f -- debian/ros-one-jsk-rosbag-tools.substvars debian/files
  	rm -fr -- debian/ros-one-jsk-rosbag-tools/ debian/tmp/
  	find .  \( \( \
  		\( -path .\*/.git -o -path .\*/.svn -o -path .\*/.bzr -o -path .\*/.hg -o -path .\*/CVS -o -path .\*/.pc -o -path .\*/_darcs \) -prune -o -type f -a \
  	        \( -name '#*#' -o -name '.*~' -o -name '*~' -o -name DEADJOE \
  		 -o -name '*.orig' -o -name '*.rej' -o -name '*.bak' \
  		 -o -name '.*.orig' -o -name .*.rej -o -name '.SUMS' \
  		 -o -name TAGS -o \( -path '*/.deps/*' -a -name '*.P' \) \
  		\) -exec rm -f {} + \) -o \
  		\( -type d -a -name autom4te.cache -prune -exec rm -rf {} + \) \)
   debian/rules build
  dh build -v --buildsystem=cmake --builddirectory=.obj-x86_64-linux-gnu
     dh_update_autotools_config -O-v -O--buildsystem=cmake -O--builddirectory=.obj-x86_64-linux-gnu
     dh_autoreconf -O-v -O--buildsystem=cmake -O--builddirectory=.obj-x86_64-linux-gnu
     debian/rules override_dh_auto_configure
  make[1]: Entering directory '/<<BUILDDIR>>package'
  # In case we're installing to a non-standard location, look for a setup.sh
  # in the install tree that was dropped by catkin, and source it.  It will
  # set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
  if [ -f "/opt/ros/one/setup.sh" ]; then . "/opt/ros/one/setup.sh"; fi && \
  dh_auto_configure -- \
  	-DCATKIN_BUILD_BINARY_PACKAGE="1" \
  	-DCMAKE_INSTALL_PREFIX="/opt/ros/one" \
  	-DCMAKE_PREFIX_PATH="/opt/ros/one" \
  	-DBUILD_TESTING=OFF -DCATKIN_ENABLE_TESTING=OFF
  	install -d .obj-x86_64-linux-gnu
  	cd .obj-x86_64-linux-gnu && cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DCMAKE_INSTALL_RUNSTATEDIR=/run "-GUnix Makefiles" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu -DCATKIN_BUILD_BINARY_PACKAGE=1 -DCMAKE_INSTALL_PREFIX=/opt/ros/one -DCMAKE_PREFIX_PATH=/opt/ros/one -DBUILD_TESTING=OFF -DCATKIN_ENABLE_TESTING=OFF ..
  CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 2.8.12 will be removed from a future version of
    CMake.
  
    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.
  
  
  -- The C compiler identification is GNU 11.2.0
  -- The CXX compiler identification is GNU 11.2.0
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /usr/bin/cc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/c++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Using CATKIN_DEVEL_PREFIX: /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/devel
  -- Using CMAKE_PREFIX_PATH: /opt/ros/one
  -- This workspace overlays: /opt/ros/one
  -- Found PythonInterp: /usr/bin/python3 (found suitable version "3.10.4", minimum required is "3") 
  -- Using PYTHON_EXECUTABLE: /usr/bin/python3
  -- Using Debian Python package layout
  -- Using empy: /usr/bin/empy
  -- Using CATKIN_ENABLE_TESTING: OFF
  -- catkin 0.8.10
  -- BUILD_SHARED_LIBS is on
  -- Found Python: /usr/bin/python3.10 (found version "3.10.4") found components: Interpreter 
  -- Using system site packages
  [rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Unable to create temporary cache file /home/runner/.ros/.rospack_cache.wvjoZw: No such file or directory
  WARNING: cannot create log directory [/sbuild-nonexistent/.ros/log]. Please set ROS_LOG_DIR to a writable location.
  [rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Unable to create temporary cache file /home/runner/.ros/.rospack_cache.Ag2KFt: No such file or directory
  WARNING: cannot create log directory [/sbuild-nonexistent/.ros/log]. Please set ROS_LOG_DIR to a writable location.
  -- Using virtualenv to run Python nosetests: 
  -- Configuring done
  -- Generating done
  CMake Warning:
    Manually-specified variables were not used by the project:
  
      BUILD_TESTING
      CMAKE_EXPORT_NO_PACKAGE_REGISTRY
      CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY
      CMAKE_INSTALL_LIBDIR
      CMAKE_INSTALL_LOCALSTATEDIR
      CMAKE_INSTALL_RUNSTATEDIR
      CMAKE_INSTALL_SYSCONFDIR
  
  
  -- Build files have been written to: /<<BUILDDIR>>package/.obj-x86_64-linux-gnu
  make[1]: Leaving directory '/<<BUILDDIR>>package'
  	rm -f debian/ros-one-jsk-rosbag-tools.debhelper.log
     debian/rules override_dh_auto_build
  make[1]: Entering directory '/<<BUILDDIR>>package'
  # In case we're installing to a non-standard location, look for a setup.sh
  # in the install tree that was dropped by catkin, and source it.  It will
  # set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
  if [ -f "/opt/ros/one/setup.sh" ]; then . "/opt/ros/one/setup.sh"; fi && \
  dh_auto_build
  	cd .obj-x86_64-linux-gnu && make -j4 "INSTALL=install --strip-program=true" VERBOSE=1
  make[2]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  /usr/bin/cmake -S/<<BUILDDIR>>package -B/<<BUILDDIR>>package/.obj-x86_64-linux-gnu --check-build-system CMakeFiles/Makefile.cmake 0
  /usr/bin/cmake -E cmake_progress_start /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/CMakeFiles /<<BUILDDIR>>package/.obj-x86_64-linux-gnu//CMakeFiles/progress.marks
  make  -f CMakeFiles/Makefile2 all
  make[3]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make  -f CMakeFiles/jsk_rosbag_tools_generate_virtualenv.dir/build.make CMakeFiles/jsk_rosbag_tools_generate_virtualenv.dir/depend
  make  -f CMakeFiles/download_audio_data.dir/build.make CMakeFiles/download_audio_data.dir/depend
  make  -f CMakeFiles/download_video_data.dir/build.make CMakeFiles/download_video_data.dir/depend
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  cd /<<BUILDDIR>>package/.obj-x86_64-linux-gnu && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /<<BUILDDIR>>package /<<BUILDDIR>>package /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/CMakeFiles/jsk_rosbag_tools_generate_virtualenv.dir/DependInfo.cmake --color=
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  cd /<<BUILDDIR>>package/.obj-x86_64-linux-gnu && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /<<BUILDDIR>>package /<<BUILDDIR>>package /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/CMakeFiles/download_audio_data.dir/DependInfo.cmake --color=
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  cd /<<BUILDDIR>>package/.obj-x86_64-linux-gnu && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /<<BUILDDIR>>package /<<BUILDDIR>>package /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/CMakeFiles/download_video_data.dir/DependInfo.cmake --color=
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make  -f CMakeFiles/jsk_rosbag_tools_generate_virtualenv.dir/build.make CMakeFiles/jsk_rosbag_tools_generate_virtualenv.dir/build
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make  -f CMakeFiles/download_audio_data.dir/build.make CMakeFiles/download_audio_data.dir/build
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make  -f CMakeFiles/download_video_data.dir/build.make CMakeFiles/download_video_data.dir/build
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  /usr/bin/python3 /opt/ros/one/share/catkin/cmake/test/download_checkmd5.py "https://drive.google.com/uc?export=download&id=1rFZYoFjLqIWjEe0DaNiL3k9893m31nu7" /<<BUILDDIR>>package/samples/data/2022-05-07-hello-test.bag 3650e27dad2c7dc0e447033259290db6 --ignore-error
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  /usr/bin/python3 /opt/ros/one/share/catkin/cmake/test/download_checkmd5.py "https://drive.google.com/uc?export=download&id=1v4YNOHnHYxLOty1lYR2R6lfNF0itCwK7" /<<BUILDDIR>>package/samples/data/20220530173950_go_to_kitchen_rosbag.bag d51fa8aeacd36f7aaa1597b67bd9ffdf --ignore-error
  [ 20%] Generate virtualenv in /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv
  catkin_generated/env_cached.sh rosrun catkin_virtualenv venv_init venv --python python3 --use-system-packages --extra-pip-args \"-qq\ --retries\ 10\ --timeout\ 30\"
  Downloading https://drive.google.com/uc?export=download&id=1v4YNOHnHYxLOty1lYR2R6lfNF0itCwK7 to /<<BUILDDIR>>package/samples/data/20220530173950_go_to_kitchen_rosbag.bag...Downloading https://drive.google.com/uc?export=download&id=1rFZYoFjLqIWjEe0DaNiL3k9893m31nu7 to /<<BUILDDIR>>package/samples/data/2022-05-07-hello-test.bag...[rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Unable to create temporary cache file /home/runner/.ros/.rospack_cache.b3120A: No such file or directory
  WARNING: cannot create log directory [/sbuild-nonexistent/.ros/log]. Please set ROS_LOG_DIR to a writable location.
   done.
  Checking md5sum on /<<BUILDDIR>>package/samples/data/2022-05-07-hello-test.bag
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  [ 20%] Built target download_audio_data
  Using pip 22.0.2 from /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/pip (python 3.10)
  Collecting pip==22.2.2
    Downloading pip-22.2.2-py3-none-any.whl (2.0 MB)
   done.
  Checking md5sum on /<<BUILDDIR>>package/samples/data/20220530173950_go_to_kitchen_rosbag.bag
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  [ 20%] Built target download_video_data
  make  -f CMakeFiles/download.dir/build.make CMakeFiles/download.dir/depend
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  cd /<<BUILDDIR>>package/.obj-x86_64-linux-gnu && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /<<BUILDDIR>>package /<<BUILDDIR>>package /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/CMakeFiles/download.dir/DependInfo.cmake --color=
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make  -f CMakeFiles/download.dir/build.make CMakeFiles/download.dir/build
  make[4]: Entering directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make[4]: Nothing to be done for 'CMakeFiles/download.dir/build'.
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  [ 20%] Built target download
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.0/2.0 MB 9.2 MB/s eta 0:00:00
  Collecting pip-tools==6.10.0
    Downloading pip_tools-6.10.0-py3-none-any.whl (53 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 53.4/53.4 KB 43.1 MB/s eta 0:00:00
  Requirement already satisfied: setuptools in ./venv/lib/python3.10/site-packages (from pip-tools==6.10.0) (59.6.0)
  Collecting click>=7
    Downloading click-8.1.8-py3-none-any.whl (98 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.2/98.2 KB 23.0 MB/s eta 0:00:00
  Collecting build
    Downloading build-1.2.2.post1-py3-none-any.whl (22 kB)
  Requirement already satisfied: wheel in /usr/lib/python3/dist-packages (from pip-tools==6.10.0) (0.37.1)
  Collecting packaging>=19.1
    Downloading packaging-24.2-py3-none-any.whl (65 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 65.5/65.5 KB 31.3 MB/s eta 0:00:00
  Collecting pyproject_hooks
    Downloading pyproject_hooks-1.2.0-py3-none-any.whl (10 kB)
  Collecting tomli>=1.1.0
    Downloading tomli-2.2.1-py3-none-any.whl (14 kB)
  Installing collected packages: tomli, pyproject_hooks, pip, packaging, click, build, pip-tools
    Attempting uninstall: pip
      Found existing installation: pip 22.0.2
      Uninstalling pip-22.0.2:
        Removing file or directory /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip
        Removing file or directory /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip3
        Removing file or directory /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip3.10
        Removing file or directory /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/pip-22.0.2.dist-info/
        Removing file or directory /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/pip/
        Successfully uninstalled pip-22.0.2
    changing mode of /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip to 755
    changing mode of /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip3 to 755
    changing mode of /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip3.10 to 755
    changing mode of /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pyproject-build to 755
    changing mode of /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip-compile to 755
    changing mode of /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip-sync to 755
  Successfully installed build-1.2.2.post1 click-8.1.8 packaging-24.2 pip-22.2.2 pip-tools-6.10.0 pyproject_hooks-1.2.0 tomli-2.2.1
  True
  [ 40%] Lock input requirements if they don't exist
  cd /<<BUILDDIR>>package && /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/catkin_generated/env_cached.sh rosrun catkin_virtualenv venv_lock /<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv --package-name jsk_rosbag_tools --input-requirements requirements.in --no-overwrite --extra-pip-args \"-qq\ --retries\ 10\ --timeout\ 30\"
  [rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Warning: cannot create rospack cache directory /home/runner/.ros: boost::filesystem::create_directory: No such file or directory: "/home/runner/.ros"
  [rospack] Unable to create temporary cache file /home/runner/.ros/.rospack_cache.hFvRiG: No such file or directory
  WARNING: cannot create log directory [/sbuild-nonexistent/.ros/log]. Please set ROS_LOG_DIR to a writable location.
  WARNING: using legacy resolver is deprecated and will be removed in future versions. The default resolver will be change to 'backtracking' in 7.0.0 version. Specify --resolver=backtracking to silence this warning.
  Traceback (most recent call last):
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip-compile", line 8, in <module>
      sys.exit(cli())
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/click/core.py", line 1161, in __call__
      return self.main(*args, **kwargs)
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/click/core.py", line 1082, in main
      rv = self.invoke(ctx)
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/click/core.py", line 1443, in invoke
      return ctx.invoke(self.callback, **ctx.params)
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/click/core.py", line 788, in invoke
      return __callback(*args, **kwargs)
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
      return f(get_current_context(), *args, **kwargs)
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/piptools/scripts/compile.py", line 550, in cli
      cache=DependencyCache(cache_dir),
    File "/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/lib/python3.10/site-packages/piptools/cache.py", line 71, in __init__
      os.makedirs(cache_dir, exist_ok=True)
    File "/usr/lib/python3.10/os.py", line 215, in makedirs
      makedirs(head, exist_ok=exist_ok)
    File "/usr/lib/python3.10/os.py", line 215, in makedirs
      makedirs(head, exist_ok=exist_ok)
    File "/usr/lib/python3.10/os.py", line 225, in makedirs
      mkdir(name, mode)
  PermissionError: [Errno 13] Permission denied: '/sbuild-nonexistent'
  Traceback (most recent call last):
    File "/opt/ros/one/lib/catkin_virtualenv/venv_lock", line 47, in <module>
      venv.lock(
    File "/opt/ros/one/lib/python3/dist-packages/catkin_virtualenv/venv.py", line 174, in lock
      run_command(command, check=True)
    File "/opt/ros/one/lib/python3/dist-packages/catkin_virtualenv/__init__.py", line 37, in run_command
      return subprocess.run(cmd, *args, **kwargs)
    File "/usr/lib/python3.10/subprocess.py", line 524, in run
      raise CalledProcessError(retcode, process.args,
  subprocess.CalledProcessError: Command '['/<<BUILDDIR>>package/.obj-x86_64-linux-gnu/venv/bin/pip-compile', '--no-header', '--annotation-style', 'line', 'requirements.in', '--pip-args', '-qq --retries 10 --timeout 30', '-o', '/<<BUILDDIR>>package/requirements.txt']' returned non-zero exit status 1.
  make[4]: *** [CMakeFiles/jsk_rosbag_tools_generate_virtualenv.dir/build.make:100: ../requirements.txt] Error 1
  make[4]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make[3]: *** [CMakeFiles/Makefile2:173: CMakeFiles/jsk_rosbag_tools_generate_virtualenv.dir/all] Error 2
  make[3]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  make[2]: *** [Makefile:139: all] Error 2
  make[2]: Leaving directory '/<<BUILDDIR>>package/.obj-x86_64-linux-gnu'
  dh_auto_build: error: cd .obj-x86_64-linux-gnu && make -j4 "INSTALL=install --strip-program=true" VERBOSE=1 returned exit code 2
  make[1]: *** [debian/rules:44: override_dh_auto_build] Error 25
  make[1]: Leaving directory '/<<BUILDDIR>>package'
  make: *** [debian/rules:27: build] Error 2
  dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
  --------------------------------------------------------------------------------
  Build finished at 2025-03-22T00:50:46Z
```
we need https://github.com/v4hn/ros-deb-builder-action/pull/10 ? 

- I'm not sure `rosdep.yaml` in this repo works. `python3-freezegun` cannot be installed by editing rosdep.yaml` only.