### PR TITLE
Fix for jsk_common and jsk_3rdparty, and maybe other catkin_virtualenv packages

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -196,7 +196,7 @@ function build_pkg {
   pkg_exists "$(deb_pkg_name "$pkg_name")" "$version" && return
 
   # Check availability of all required packages (bloom-generate waits for input on rosdep issues)
-  rosdep install --os="$DISTRIBUTION:$DEB_DISTRO" --simulate --from-paths . > /dev/null || return 2
+  rosdep install --os="$DISTRIBUTION:$DEB_DISTRO" --simulate -t build -t buildtool_export -t buildtool -t build_export -t exec --from-paths . > /dev/null || return 2
   ici_label "${BLOOM_QUIET[@]}" bloom-generate "${BLOOM_GEN_CMD}" --os-name="$DISTRIBUTION" --os-version="$DEB_DISTRO" --ros-distro="$ROS_DISTRO" || return 2
 
   trap 'rm -f ../*.dsc ../*.tar.gz; cd "$old_path"' RETURN # cleanup on build failure

--- a/src/build.sh
+++ b/src/build.sh
@@ -197,7 +197,7 @@ function build_pkg {
 
   # Check availability of all required packages (bloom-generate waits for input on rosdep issues)
   rosdep install --os="$DISTRIBUTION:$DEB_DISTRO" --simulate -t build -t buildtool_export -t buildtool -t build_export -t exec --from-paths . > /dev/null || return 2
-  ici_label "${BLOOM_QUIET[@]}" bloom-generate "${BLOOM_GEN_CMD}" --os-name="$DISTRIBUTION" --os-version="$DEB_DISTRO" --ros-distro="$ROS_DISTRO" || return 2
+  ici_label "${BLOOM_QUIET[@]}" bloom-generate "${BLOOM_GEN_CMD}" --os-name="$DISTRIBUTION" --os-version="$DEB_DISTRO" --ros-distro="$ROS_DISTRO" --skip-test-dependencies || return 2
 
   trap 'rm -f ../*.dsc ../*.tar.gz; cd "$old_path"' RETURN # cleanup on build failure
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -197,7 +197,7 @@ function build_pkg {
 
   # Check availability of all required packages (bloom-generate waits for input on rosdep issues)
   rosdep install --os="$DISTRIBUTION:$DEB_DISTRO" --simulate -t build -t buildtool_export -t buildtool -t build_export -t exec --from-paths . > /dev/null || return 2
-  ici_label "${BLOOM_QUIET[@]}" bloom-generate "${BLOOM_GEN_CMD}" --os-name="$DISTRIBUTION" --os-version="$DEB_DISTRO" --ros-distro="$ROS_DISTRO" --skip-test-dependencies || return 2
+  ici_label "${BLOOM_QUIET[@]}" bloom-generate "${BLOOM_GEN_CMD}" --os-name="$DISTRIBUTION" --os-version="$DEB_DISTRO" --ros-distro="$ROS_DISTRO" --skip-test-dependencies --skip-pip || return 2
 
   trap 'rm -f ../*.dsc ../*.tar.gz; cd "$old_path"' RETURN # cleanup on build failure
 

--- a/src/scripts/prepare.sh
+++ b/src/scripts/prepare.sh
@@ -35,7 +35,7 @@ DEBIAN_FRONTEND=noninteractive ici_timed "Install build packages" ici_cmd "${APT
 	python3-stdeb python3-all dh-python build-essential
 
 # Install patched bloom to handle ROS "one" distro key when resolving python and ROS version
-ici_timed "Install bloom" ici_asroot pip install -U git+https://github.com/rhaschke/bloom.git@ros-one
+ici_timed "Install bloom" ici_asroot pip install -U git+https://github.com/k-okada/bloom.git@ros-one
 # Install patched vcstool to allow for treeless clones
 ici_timed "Install vcstool" ici_asroot pip install -U git+https://github.com/rhaschke/vcstool.git@master
 


### PR DESCRIPTION
@rhaschke 
sorry for late, to work with jsk package, 
1) we need to use patched veresion of bloom, `--skip-pip` and `--skip-test-dependcies`, Of course , theoretically, we could remove those depends from our package.xml but we have been using our `--skip-pip` for releasing debs and also before bloom 0.11.0, the test_depends is not included in debian dependenceis, that's why we use 0.10.7 at https://github.com/k-okada/ros-deb-builder-action/commit/df26dd284509c3657858f4cd2592f3654968a5a9#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R5-R11
2) jsk packges uses a lot of catkin_virtualenv, and we need https://github.com/v4hn/ros-deb-builder-action/pull/10/files to run within recent version of sbuild

I have checked this works well on jsk_common/noble at https://github.com/k-okada/ros-builder-action/actions/runs/14280932656 and currently testing for jsk_3rdparty at https://github.com/k-okada/ros-builder-action/actions/runs/14293996419

c.f. https://github.com/ubi-agni/ros-builder-action/pull/32