### PR TITLE
Add catch_ros to ros-one.repos

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -103,6 +103,10 @@ repositories:
     type: git
     url: https://github.com/ros-o/camera_info_manager_py.git
     version: obese-devel
+  catch_ros:
+    type: git
+    url: https://github.com/AIS-Bonn/catch_ros.git
+    version: master
   catkin:
     type: git
     url: https://github.com/ros-o/catkin.git


### PR DESCRIPTION
To have better integration of `Catch2` with ROS.

For details, please refer to the readme in the repository:
https://github.com/AIS-Bonn/catch_ros

Tested on my fork: https://github.com/furushchev/ros-builder-action/actions/runs/14321151940