### PR TITLE
Use ros/resource_retriever

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -673,8 +673,8 @@ repositories:
     version: melodic-devel
   resource_retriever:
     type: git
-    url: https://github.com/ros-o/resource_retriever.git
-    version: obese-devel
+    url: https://github.com/ros/resource_retriever.git
+    version: noetic-devel
   rgbd_launch:
     type: git
     url: https://github.com/ros-drivers/rgbd_launch.git


### PR DESCRIPTION
As mentioned in the https://github.com/ros-o/resource_retriever, all changes needed for the ROS-O has been merged into the upstream package, it does not need to use ros-o fork.