### PR TITLE
add mavros and related repository

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -419,6 +419,14 @@ repositories:
     type: git
     url: https://github.com/Neargye/magic_enum.git
     version: master
+  mavlink:
+    type: git
+    url: https://github.com/mavlink/mavlink-gbp-release.git
+    version: release/noetic/mavlink
+  mavros:
+    type: git
+    url: https://github.com/ros-o/mavros.git
+    version: obese-devel
   media_export:
     type: git
     url: https://github.com/ros/media_export.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -421,7 +421,7 @@ repositories:
     version: master
   mavlink:
     type: git
-    url: https://github.com/sugikazu75/mavlink-gbp-release.git
+    url: https://github.com/ros-o/mavlink-gbp-release.git
     version: obese-devel
   mavros:
     type: git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -421,8 +421,8 @@ repositories:
     version: master
   mavlink:
     type: git
-    url: https://github.com/mavlink/mavlink-gbp-release.git
-    version: release/noetic/mavlink
+    url: https://github.com/sugikazu75/mavlink-gbp-release.git
+    version: obese-devel
   mavros:
     type: git
     url: https://github.com/ros-o/mavros.git


### PR DESCRIPTION
I added `mavlink` and `mavros` .
Build process is confirmed on https://github.com/sugikazu75/ros-builder-action/actions/runs/14550740932 

A patch for ROS-O was required https://github.com/mavlink/mavlink-gbp-release/compare/release/noetic/mavlink...sugikazu75:mavlink-gbp-release:obese-devel 

@k-okada @mqcmd196
If you have write access to ROS-O organization, could you create fork of https://github.com/sugikazu75/mavlink-gbp-release/tree/obese-devel ? 
