### PR TITLE
Add robot_localization to ros-one.repos

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -718,6 +718,10 @@ repositories:
     type: git
     url: https://github.com/mikeferguson/robot_calibration.git
     version: ros1
+  robot_localization:
+    type: git
+    url: https://github.com/cra-ros-pkg/robot_localization.git
+    version: noetic-devel
   robot_pose_ekf:
     type: git
     url: https://github.com/ros-planning/robot_pose_ekf.git


### PR DESCRIPTION
Tested on my fork:
- jammy: https://github.com/furushchev/ros-builder-action/actions/runs/14888240575
- noble: https://github.com/furushchev/ros-builder-action/actions/runs/14888247211