### PR TITLE
Add move_base_flex to ros-one.repos

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -474,6 +474,10 @@ repositories:
     type: git
     url: https://github.com/ros-o/mongodb_store.git
     version: obese-devel
+  move_base_flex:
+    type: git
+    url: https://github.com/naturerobots/move_base_flex.git
+    version: master
   moveit:
     type: git
     url: https://github.com/moveit/moveit.git


### PR DESCRIPTION
Tested on my fork repo:
- jammy: https://github.com/furushchev/ros-builder-action/actions/runs/14890126812
- noble: https://github.com/furushchev/ros-builder-action/actions/runs/14890132998