### PR TITLE
Add teb_local_planner to ros-one.repos

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -162,6 +162,10 @@ repositories:
     type: git
     url: https://github.com/ros/convex_decomposition.git
     version: melodic-devel
+  costmap_converter:
+    type: git
+    url: https://github.com/rst-tu-dortmund/costmap_converter.git
+    version: master
   criutils:
     type: git
     url: https://github.com/crigroup/criutils.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -1038,6 +1038,10 @@ repositories:
     type: git
     url: https://github.com/ros/std_msgs.git
     version: kinetic-devel
+  teb_local_planner:
+    type: git
+    url: https://github.com/rst-tu-dortmund/teb_local_planner.git
+    version: noetic-devel
   teleop_tools:
     type: git
     url: https://github.com/ros-teleop/teleop_tools.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -1040,8 +1040,8 @@ repositories:
     version: kinetic-devel
   teb_local_planner:
     type: git
-    url: https://github.com/rst-tu-dortmund/teb_local_planner.git
-    version: noetic-devel
+    url: https://github.com/ros-o/teb_local_planner.git
+    version: obese-devel
   teleop_tools:
     type: git
     url: https://github.com/ros-teleop/teleop_tools.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -164,8 +164,8 @@ repositories:
     version: melodic-devel
   costmap_converter:
     type: git
-    url: https://github.com/rst-tu-dortmund/costmap_converter.git
-    version: master
+    url: https://github.com/ros-o/costmap_converter.git
+    version: obese-devel
   criutils:
     type: git
     url: https://github.com/crigroup/criutils.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -426,6 +426,10 @@ repositories:
     type: git
     url: https://github.com/rhaschke/libfranka.git
     version: master
+  libg2o:
+    type: git
+    url: https://github.com/ros-gbp/libg2o-release.git
+    version: upstream
   librealsense2:
     type: git
     url: https://github.com/ros-o/librealsense.git


### PR DESCRIPTION
Some changes have to be made to support on jammy and noble, so I forked to `ros-o` org while the changes are now sent to upstream:
- https://github.com/rst-tu-dortmund/costmap_converter/pull/46
- https://github.com/rst-tu-dortmund/teb_local_planner/pull/431

Tested on my fork repo:
- noble: https://github.com/furushchev/ros-builder-action/actions/runs/14919504151
- jammy: https://github.com/furushchev/ros-builder-action/actions/runs/14917676352