### PR TITLE
Use bfl from source

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -87,6 +87,10 @@ repositories:
     type: git
     url: https://github.com/RethinkRobotics/baxter_common.git
     version: master
+  bfl:
+    type: git
+    url: https://github.com/ros-gbp/bfl-release.git
+    version: upstream
   bio_ik:
     type: git
     url: https://github.com/TAMS-Group/bio_ik.git
@@ -1182,10 +1186,6 @@ known_failures:
     - pr2_simulator/*
     - pr2_ethercat_drivers/ethercat_hardware  # deprecation of boost/timer.hpp
     - pr2_robot/pr2_ethercat
-    - people/people_tracking_filter  # missing bfl?
-    - people/leg_detector
-    - robot_pose_ekf  # missing bfl?
-    - moveit_calibration/*  # missing bfl?
   "arm64/*":
     - ros_realtime/rosrt  # multiple definition of boost::atomic_signal_fence
     - prosilica_*  # cmake error: No SOURCES given to target: PvAPI


### PR DESCRIPTION
As pointed out in #63 `bfl` is not available as a system package in Noble anymore.