### PR TITLE
Add hector_slam to ROS One repos

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -324,8 +324,8 @@ repositories:
     version: master
   hector_slam:
     type: git
-    url: https://github.com/mcamurri/hector_slam.git
-    version: ros-o-devel
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
+    version: noetic-devel
   hpp-fcl:
     type: git
     url: https://github.com/humanoid-path-planner/hpp-fcl.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -322,6 +322,10 @@ repositories:
     type: git
     url: https://github.com/crigroup/handeye.git
     version: master
+  hector_slam:
+    type: git
+    url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
+    version: noetic-devel
   hpp-fcl:
     type: git
     url: https://github.com/humanoid-path-planner/hpp-fcl.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -324,8 +324,8 @@ repositories:
     version: master
   hector_slam:
     type: git
-    url: https://github.com/tu-darmstadt-ros-pkg/hector_slam.git
-    version: noetic-devel
+    url: https://github.com/mcamurri/hector_slam.git
+    version: ros-o-devel
   hpp-fcl:
     type: git
     url: https://github.com/humanoid-path-planner/hpp-fcl.git


### PR DESCRIPTION
As per instructions detailed in [here](https://ros.packages.techfak.net/), I'm opening a PR to expand the list of repositories to include `hector_slam`. I personally need only the `hector_trajectory_server` package, which locally compiles just fine on my Ubuntu 24.04 machine.