### PR TITLE
Cleanup builder

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,7 +131,7 @@ env:
 
 jobs:
   debs:
-    runs-on: ${{ inputs.ARCH  == 'x64' && 'ubuntu-22.04' || (inputs.ARCH == 'arm64' && 'ubuntu-22.04-arm' || inputs.ARCH) }}
+    runs-on: ${{ inputs.ARCH  == 'x64' && 'ubuntu-latest' || (inputs.ARCH == 'arm64' && 'ubuntu-22.04-arm' || inputs.ARCH) }}
     timeout-minutes: ${{ inputs.ARCH  == 'x64' && 340 || 2880 }}
     name: build debs
     outputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   sanity:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,7 +39,7 @@ jobs:
           name: pre-commit
 
   unittests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -76,7 +76,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: (inputs.DEPLOY_URL || vars.DEPLOY_URL) && (inputs.DEBS_ARTIFACT_NAME != 'skip')
     env:
       DEBUG_BASH: ${{ secrets.ACTIONS_STEP_DEBUG && 'true' || 'false' }}

--- a/.github/workflows/docker.build.yaml
+++ b/.github/workflows/docker.build.yaml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: rhaschke/docker-run-action@main

--- a/.github/workflows/interactive.yaml
+++ b/.github/workflows/interactive.yaml
@@ -83,9 +83,9 @@ jobs:
       INSTALL_GPG_KEYS: |
         sudo curl -sSL https://ros.packages.techfak.net/gpg.key -o /etc/apt/keyrings/ros-one-keyring.gpg
       EXTRA_DEB_SOURCES: >-
-          "${{ inputs.CONTINUE_BUILD &&
-               format('deb [signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net {0}-testing main',
-                      inputs.DEB_DISTRO) || '' }}"
+          ${{ inputs.CONTINUE_BUILD &&
+              format('deb [signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net {0}-testing main',
+                     inputs.DEB_DISTRO) || '' }}
       EXTRA_ROSDEP_SOURCES: |
         rosdep.yaml
         https://ros.packages.techfak.net/ros-one.yaml
@@ -109,9 +109,9 @@ jobs:
       INSTALL_GPG_KEYS: |
         sudo curl -sSL https://ros.packages.techfak.net/gpg.key -o /etc/apt/keyrings/ros-one-keyring.gpg
       EXTRA_DEB_SOURCES: >-
-          "${{ inputs.CONTINUE_BUILD &&
-               format('deb [signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net {0}-testing main',
-                      inputs.DEB_DISTRO) || '' }}"
+          ${{ inputs.CONTINUE_BUILD &&
+              format('deb [signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net {0}-testing main',
+                     inputs.DEB_DISTRO) || '' }}
       EXTRA_ROSDEP_SOURCES: |
         rosdep.yaml
         https://ros.packages.techfak.net/ros-one.yaml
@@ -135,9 +135,9 @@ jobs:
       INSTALL_GPG_KEYS: |
         sudo curl -sSL https://ros.packages.techfak.net/gpg.key -o /etc/apt/keyrings/ros-one-keyring.gpg
       EXTRA_DEB_SOURCES: >-
-          "${{ inputs.CONTINUE_BUILD &&
-               format('deb [signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net {0}-testing main',
-                      inputs.DEB_DISTRO) || '' }}"
+          ${{ inputs.CONTINUE_BUILD &&
+              format('deb [signed-by=/etc/apt/keyrings/ros-one-keyring.gpg] https://ros.packages.techfak.net {0}-testing main',
+                     inputs.DEB_DISTRO) || '' }}
       EXTRA_ROSDEP_SOURCES: |
         rosdep.yaml
         https://ros.packages.techfak.net/ros-one.yaml

--- a/.github/workflows/packages.build.yaml
+++ b/.github/workflows/packages.build.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: "${{ inputs.DEB_DISTRO }}-${{ inputs.ARCH }}"
-    runs-on: ${{ inputs.ARCH  == 'x64' && 'ubuntu-22.04' || (inputs.ARCH == 'arm64' && 'ubuntu-22.04-arm' || inputs.ARCH) }}
+    runs-on: ${{ inputs.ARCH  == 'x64' && 'ubuntu-latest' || (inputs.ARCH == 'arm64' && 'ubuntu-22.04-arm' || inputs.ARCH) }}
 
     steps:
       - run: pip install gitpython

--- a/src/README.md.in
+++ b/src/README.md.in
@@ -3,10 +3,6 @@
 ## Install
 
 ```bash
-# Configure ROS 2 apt repository
-sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /etc/apt/keyrings/ros-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list
-
 # Configure custom ROS repository
 echo "deb [trusted=yes] @REPO_URL@ ./" | sudo tee /etc/apt/sources.list.d/@DISTRO_NAME@.list
 

--- a/src/scripts/prepare.sh
+++ b/src/scripts/prepare.sh
@@ -32,12 +32,15 @@ echo apt-cacher-ng apt-cacher-ng/tunnelenable boolean true | ici_asroot debconf-
 DEBIAN_FRONTEND=noninteractive ici_timed "Install build packages" ici_cmd "${APT_QUIET[@]}" ici_apt_install \
 	mmdebstrap sbuild schroot devscripts ccache apt-cacher-ng python3-pip python3-rosdep libxml2-utils libarchive-tools \
 	python3-colcon-package-information python3-colcon-package-selection python3-colcon-ros python3-colcon-cmake \
-	python3-stdeb python3-all dh-python build-essential
+	debhelper python3-all dh-python build-essential
 
+export PIP_BREAK_SYSTEM_PACKAGES=1
 # Install patched bloom to handle ROS "one" distro key when resolving python and ROS version
 ici_timed "Install bloom" ici_asroot pip install -U git+https://github.com/rhaschke/bloom.git@ros-one
 # Install patched vcstool to allow for treeless clones
 ici_timed "Install vcstool" ici_asroot pip install -U git+https://github.com/rhaschke/vcstool.git@master
+# Install latest stdeb
+ici_timed "Install stdeb" ici_asroot pip install -U git+https://github.com/astraw/stdeb@master
 
 # Remove ros2 package repository, now that rosdep and colcon are installed
 # This repo might have newer versions, e.g. of colcon, than the ones to be built

--- a/src/scripts/prepare.sh
+++ b/src/scripts/prepare.sh
@@ -14,11 +14,6 @@ ici_append INSTALL_HOST_GPG_KEYS "sudo apt-key adv --keyserver keyserver.ubuntu.
 ici_append EXTRA_HOST_SOURCES "deb http://ppa.launchpad.net/v-launchpad-jochen-sprickerhof-de/sbuild/ubuntu jammy main"
 ici_cmd restrict_src_to_packages "release o=v-launchpad-jochen-sprickerhof-de" "mmdebstrap sbuild"
 
-# ROS for python3-rosdep, python3-colcon-*
-ros_key_file="/etc/apt/keyrings/ros-archive-keyring.gpg"
-ici_append INSTALL_HOST_GPG_KEYS "sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o $ros_key_file"
-ici_append EXTRA_HOST_SOURCES "deb [signed-by=$ros_key_file] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main"
-
 # Configure sources
 ici_hook INSTALL_HOST_GPG_KEYS
 ici_timed "Configure EXTRA_HOST_SOURCES" configure_extra_host_sources
@@ -30,8 +25,7 @@ echo apt-cacher-ng apt-cacher-ng/tunnelenable boolean true | ici_asroot debconf-
 
 # Install packages on host
 DEBIAN_FRONTEND=noninteractive ici_timed "Install build packages" ici_cmd "${APT_QUIET[@]}" ici_apt_install \
-	mmdebstrap sbuild schroot devscripts ccache apt-cacher-ng python3-pip python3-rosdep libxml2-utils libarchive-tools \
-	python3-colcon-package-information python3-colcon-package-selection python3-colcon-ros python3-colcon-cmake \
+	mmdebstrap sbuild schroot devscripts ccache apt-cacher-ng python3-pip libxml2-utils libarchive-tools \
 	debhelper python3-all dh-python build-essential
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
@@ -41,11 +35,8 @@ ici_timed "Install bloom" ici_asroot pip install -U git+https://github.com/rhasc
 ici_timed "Install vcstool" ici_asroot pip install -U git+https://github.com/rhaschke/vcstool.git@master
 # Install latest stdeb
 ici_timed "Install stdeb" ici_asroot pip install -U git+https://github.com/astraw/stdeb@master
-
-# Remove ros2 package repository, now that rosdep and colcon are installed
-# This repo might have newer versions, e.g. of colcon, than the ones to be built
-ici_asroot sed -i '/packages.ros.org\/ros2\/ubuntu/d' "$REPOS_LIST_FILE"
-ici_timed "Update apt package list" ici_asroot apt-get update
+# Install colcon and rosdep from pypi
+ici_timed "Install rosdep and colcon" ici_asroot pip install -U rosdep colcon-package-information colcon-package-selection colcon-ros colcon-cmake
 
 # remove existing rosdep config to avoid conflicts with rosdep init
 ici_asroot rm -f /etc/ros/rosdep/sources.list.d/20-default.list


### PR DESCRIPTION
- [x] Switch to `ubuntu-latest` image (24.04)
  - [ ] Fix python debian build workflow
- [x] Remove ros2 repository dependency (used for rosdep + colcon -> install them from pypi on the builder)
   This uses `python3-catkin-pkg` from the native Ubuntu repos!
- [ ] Build catkin-pkg ourselves