### PR TITLE
use catkin-supported BehaviorTree.CPP

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -2,7 +2,7 @@ repositories:
   BehaviorTree.CPP:
     type: git
     url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
-    version: 3c62813b84fa9b26d8cb88dc38da17deb852f6a7
+    version: 3a00bc307e511611203fdd0acdaadbad8d68a772
   Stage:
     type: git
     url: https://github.com/ros-o/Stage.git


### PR DESCRIPTION
The previous version was accidentally picked in befd3424b1174d21e56835b77493b664fb4bb783 and the commit statement there states 4.7.1 removed catkin-support. But it was actually commit https://github.com/BehaviorTree/BehaviorTree.CPP/commit/ac26aea241d4d38a45d9e35eb0507537a0e46b05 before 4.7.0 that removed the support.

3a00bc307e511611203fdd0acdaadbad8d68a772 is the last commit before that one.