### PR TITLE
Update jsk_control repository URL

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -396,8 +396,8 @@ repositories:
     version: master
   jsk_control:
     type: git
-    url: https://github.com/ros-o/jsk_control.git
-    version: obese-devel
+    url: https://github.com/jsk-ros-pkg/jsk_control.git
+    version: master
   jsk_model_tools:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_model_tools.git


### PR DESCRIPTION
The patches for the latest Ubuntu release

- https://github.com/jsk-ros-pkg/jsk_control/pull/794

has been merged