### PR TITLE
Add patched grid_map

### DIFF
--- a/ros-one.repos
+++ b/ros-one.repos
@@ -338,6 +338,10 @@ repositories:
     type: git
     url: https://github.com/PickNikRobotics/graph_msgs.git
     version: jade-devel
+  grid_map:
+    type: git
+    url: https://github.com/TobinHall/grid_map
+    version: obese-devel
   handeye:
     type: git
     url: https://github.com/crigroup/handeye.git

--- a/ros-one.repos
+++ b/ros-one.repos
@@ -340,7 +340,7 @@ repositories:
     version: jade-devel
   grid_map:
     type: git
-    url: https://github.com/TobinHall/grid_map
+    url: https://github.com/ros-o/grid_map
     version: obese-devel
   handeye:
     type: git


### PR DESCRIPTION
I have forked [grid_map](https://github.com/ANYbotics/grid_map) and patched it to build on noble. 

The [patch](https://github.com/ANYbotics/grid_map/compare/master...TobinHall:grid_map:obese-devel) was minimal changes to build - unpinning an exact cmake requirement and removing deprected api calls.

I tried to match the ROS2 branches of the repo as closely as possible. I have only validated that the changes are able to be built.

I am happy for this patched version to be moved to the ros-o organisation, but I have not had time to start a discussion.