### PR TITLE
Add catkin-pkg and rosdep for rospack

### DIFF
--- a/python.repos
+++ b/python.repos
@@ -7,6 +7,10 @@ repositories:
     type: git
     url: https://github.com/catkin/catkin_tools
     version: main
+  catkin-pkg:
+    type: git
+    url: https://github.com/ros-infrastructure/catkin_pkg.git
+    version: master
   colcon-alias:
     type: git
     url: https://github.com/colcon/colcon-alias.git
@@ -118,4 +122,8 @@ repositories:
   colcon-zsh:
     type: git
     url: https://github.com/colcon/colcon-zsh.git
+    version: master
+  rosdep:
+    type: git
+    url: https://github.com/ros-infrastructure/rosdep.git
     version: master

--- a/rosdep.yaml
+++ b/rosdep.yaml
@@ -53,3 +53,9 @@ orocos_kdl: # needed for robot_calibration, pr2_head_action, ...
 urdfdom:
   debian: [liburdfdom-dev]
   ubuntu: [liburdfdom-dev]
+
+python3-catkin-pkg-modules:
+  ubuntu: [python3-catkin-pkg]
+
+python3-rosdep-modules:
+  ubuntu: [python3-rosdep]


### PR DESCRIPTION
catkin-pkg is actually still provided in Ubuntu so maybe just the change in rospack package.xml is needed? Or an entry to rosdep.yaml to map `python3-catkin-pkg-modules` to `python3-catkin-pkg`

`python3-rosdep` is no longer provided since a few Ubuntu releases

fixes #111 